### PR TITLE
feat: ローカル保存ディレクトリ構造を実装する

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,9 @@ tracing-log = "0.2"
 dirs = "6"
 anyhow = "1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.59", features = [
     "Win32_Foundation",

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use crate::services::capture::CaptureService;
 use crate::services::editor::EditorService;
 use crate::services::settings::SettingsService;
+use crate::services::storage::StorageService;
 use crate::services::thumbnail::ThumbnailService;
 use crate::services::workspace::WorkspaceService;
 
@@ -16,5 +17,6 @@ pub struct AppState {
     pub settings_service: Box<dyn SettingsService>,
     pub editor_service: Box<dyn EditorService>,
     pub thumbnail_service: Box<dyn ThumbnailService>,
+    pub storage_service: Box<dyn StorageService>,
     pub db_conn: Arc<Mutex<rusqlite::Connection>>,
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
 pub mod editor;
 pub mod settings;
+pub mod storage;
 pub mod workspace;

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -1,0 +1,50 @@
+use serde::Serialize;
+use tauri::State;
+
+use crate::app_state::AppState;
+use crate::error::CommandResult;
+
+/// Response payload for storage directory paths.
+#[derive(Debug, Serialize)]
+pub struct StoragePaths {
+    pub base_path: String,
+    pub originals_dir: String,
+    pub edited_dir: String,
+    pub thumbnails_dir: String,
+    pub videos_dir: String,
+}
+
+/// Get all storage directory paths.
+#[tauri::command]
+pub fn get_storage_paths(state: State<'_, AppState>) -> CommandResult<StoragePaths> {
+    let resolver = state.storage_service.resolver();
+    CommandResult::ok(StoragePaths {
+        base_path: resolver.base_path().to_string_lossy().to_string(),
+        originals_dir: resolver.originals_dir().to_string_lossy().to_string(),
+        edited_dir: resolver.edited_dir().to_string_lossy().to_string(),
+        thumbnails_dir: resolver.thumbnails_dir().to_string_lossy().to_string(),
+        videos_dir: resolver.videos_dir().to_string_lossy().to_string(),
+    })
+}
+
+/// Resolve a specific file path within the storage structure.
+#[tauri::command]
+pub fn resolve_storage_path(
+    category: String,
+    filename: String,
+    state: State<'_, AppState>,
+) -> CommandResult<String> {
+    let path = match category.as_str() {
+        "originals" => state.storage_service.resolve_original_path(&filename),
+        "edited" => state.storage_service.resolve_edited_path(&filename),
+        "thumbnails" => state.storage_service.resolve_thumbnail_path(&filename),
+        "videos" => state.storage_service.resolve_video_path(&filename),
+        _ => {
+            return CommandResult::err(format!(
+                "Unknown storage category: '{}'. Valid categories: originals, edited, thumbnails, videos",
+                category
+            ));
+        }
+    };
+    CommandResult::ok(path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -1,8 +1,24 @@
+use std::path::Path;
+
 use serde::Serialize;
 use tauri::State;
 
 use crate::app_state::AppState;
 use crate::error::CommandResult;
+
+fn sanitize_filename(filename: &str) -> Result<String, String> {
+    match Path::new(filename).file_name() {
+        Some(name) => {
+            let safe = name.to_string_lossy();
+            if safe.is_empty() {
+                Err("Invalid filename".to_string())
+            } else {
+                Ok(safe.to_string())
+            }
+        }
+        None => Err("Invalid filename".to_string()),
+    }
+}
 
 /// Response payload for storage directory paths.
 #[derive(Debug, Serialize)]
@@ -34,11 +50,16 @@ pub fn resolve_storage_path(
     filename: String,
     state: State<'_, AppState>,
 ) -> CommandResult<String> {
+    let safe_filename = match sanitize_filename(&filename) {
+        Ok(name) => name,
+        Err(e) => return CommandResult::err(e),
+    };
+
     let path = match category.as_str() {
-        "originals" => state.storage_service.resolve_original_path(&filename),
-        "edited" => state.storage_service.resolve_edited_path(&filename),
-        "thumbnails" => state.storage_service.resolve_thumbnail_path(&filename),
-        "videos" => state.storage_service.resolve_video_path(&filename),
+        "originals" => state.storage_service.resolve_original_path(&safe_filename),
+        "edited" => state.storage_service.resolve_edited_path(&safe_filename),
+        "thumbnails" => state.storage_service.resolve_thumbnail_path(&safe_filename),
+        "videos" => state.storage_service.resolve_video_path(&safe_filename),
         _ => {
             return CommandResult::err(format!(
                 "Unknown storage category: '{}'. Valid categories: originals, edited, thumbnails, videos",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ use crate::repositories::workspace::SqliteWorkspaceRepository;
 use crate::services::capture::DefaultCaptureService;
 use crate::services::editor::DefaultEditorService;
 use crate::services::settings::DefaultSettingsService;
+use crate::services::storage::DefaultStorageService;
 use crate::services::thumbnail::DefaultThumbnailService;
 use crate::services::workspace::DefaultWorkspaceService;
 
@@ -75,12 +76,15 @@ pub fn run() {
             let workspace_repo = SqliteWorkspaceRepository::new(Arc::clone(&conn));
             let settings_repo = SqliteSettingsRepository::new(Arc::clone(&conn));
 
+            let storage_service = DefaultStorageService::new(save_path);
+
             let app_state = AppState {
                 capture_service: Box::new(DefaultCaptureService::new()),
                 workspace_service: Box::new(DefaultWorkspaceService::new(workspace_repo)),
                 settings_service: Box::new(DefaultSettingsService::new(settings_repo)),
                 editor_service: Box::new(DefaultEditorService::new()),
                 thumbnail_service: Box::new(DefaultThumbnailService::new()),
+                storage_service: Box::new(storage_service),
                 db_conn: conn,
             };
 
@@ -100,6 +104,8 @@ pub fn run() {
             commands::editor::redo,
             commands::settings::get_settings,
             commands::settings::save_settings,
+            commands::storage::get_storage_paths,
+            commands::storage::resolve_storage_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod capture;
 pub mod editor;
 pub mod settings;
+pub mod storage;
 pub mod thumbnail;
 pub mod workspace;

--- a/src-tauri/src/services/storage.rs
+++ b/src-tauri/src/services/storage.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+
+use crate::error::AppResult;
+use crate::storage::StoragePathResolver;
+
+/// Service trait for storage path resolution and directory management.
+pub trait StorageService: Send + Sync {
+    /// Get the base save path.
+    fn get_base_path(&self) -> PathBuf;
+
+    /// Ensure all storage directories exist. Creates them if missing.
+    fn ensure_directories(&self) -> AppResult<()>;
+
+    /// Get the path resolver for this storage configuration.
+    fn resolver(&self) -> &StoragePathResolver;
+
+    /// Resolve the full path for an original file.
+    fn resolve_original_path(&self, filename: &str) -> PathBuf;
+
+    /// Resolve the full path for an edited file.
+    fn resolve_edited_path(&self, filename: &str) -> PathBuf;
+
+    /// Resolve the unique thumbnail path for a given original filename.
+    fn resolve_thumbnail_path(&self, original_filename: &str) -> PathBuf;
+
+    /// Resolve the full path for a video file.
+    fn resolve_video_path(&self, filename: &str) -> PathBuf;
+}
+
+/// Default storage service backed by a `StoragePathResolver`.
+pub struct DefaultStorageService {
+    resolver: StoragePathResolver,
+}
+
+impl DefaultStorageService {
+    /// Create a new storage service with the given base save path.
+    pub fn new(base_path: PathBuf) -> Self {
+        Self {
+            resolver: StoragePathResolver::new(base_path),
+        }
+    }
+}
+
+impl StorageService for DefaultStorageService {
+    fn get_base_path(&self) -> PathBuf {
+        self.resolver.base_path().to_path_buf()
+    }
+
+    fn ensure_directories(&self) -> AppResult<()> {
+        crate::storage::ensure_storage_dirs(self.resolver.base_path())
+    }
+
+    fn resolver(&self) -> &StoragePathResolver {
+        &self.resolver
+    }
+
+    fn resolve_original_path(&self, filename: &str) -> PathBuf {
+        self.resolver.original_path(filename)
+    }
+
+    fn resolve_edited_path(&self, filename: &str) -> PathBuf {
+        self.resolver.edited_path(filename)
+    }
+
+    fn resolve_thumbnail_path(&self, original_filename: &str) -> PathBuf {
+        self.resolver.thumbnail_path(original_filename)
+    }
+
+    fn resolve_video_path(&self, filename: &str) -> PathBuf {
+        self.resolver.video_path(filename)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_storage_service_paths() {
+        let svc = DefaultStorageService::new(PathBuf::from("/tmp/test"));
+
+        assert_eq!(
+            svc.resolve_original_path("a.png"),
+            PathBuf::from("/tmp/test/originals/a.png")
+        );
+        assert_eq!(
+            svc.resolve_edited_path("a.png"),
+            PathBuf::from("/tmp/test/edited/a.png")
+        );
+        assert_eq!(
+            svc.resolve_thumbnail_path("a.png"),
+            PathBuf::from("/tmp/test/thumbnails/a_thumb.png")
+        );
+        assert_eq!(
+            svc.resolve_video_path("b.mp4"),
+            PathBuf::from("/tmp/test/videos/b.mp4")
+        );
+    }
+
+    #[test]
+    fn test_ensure_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let svc = DefaultStorageService::new(temp.path().to_path_buf());
+
+        svc.ensure_directories().unwrap();
+
+        assert!(temp.path().join("originals").exists());
+        assert!(temp.path().join("edited").exists());
+        assert!(temp.path().join("thumbnails").exists());
+        assert!(temp.path().join("videos").exists());
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -116,7 +116,12 @@ impl StoragePathResolver {
     /// - `noext` → `noext_thumb`
     pub fn thumbnail_filename(original_filename: &str) -> String {
         let path = Path::new(original_filename);
-        match (path.file_stem(), path.extension()) {
+        let file_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let name_path = Path::new(&file_name);
+        match (name_path.file_stem(), name_path.extension()) {
             (Some(stem), Some(ext)) => {
                 format!("{}_thumb.{}", stem.to_string_lossy(), ext.to_string_lossy())
             }
@@ -211,6 +216,30 @@ mod tests {
         assert_eq!(
             StoragePathResolver::thumbnail_filename("noext"),
             "noext_thumb"
+        );
+    }
+
+    #[test]
+    fn test_thumbnail_filename_with_subdirectory() {
+        assert_eq!(
+            StoragePathResolver::thumbnail_filename("subdir/capture_001.png"),
+            "capture_001_thumb.png"
+        );
+    }
+
+    #[test]
+    fn test_thumbnail_filename_with_deep_subdirectory() {
+        assert_eq!(
+            StoragePathResolver::thumbnail_filename("a/b/c/photo.jpg"),
+            "photo_thumb.jpg"
+        );
+    }
+
+    #[test]
+    fn test_thumbnail_filename_with_path_traversal() {
+        assert_eq!(
+            StoragePathResolver::thumbnail_filename("../../../etc/passwd"),
+            "passwd_thumb"
         );
     }
 

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1,11 +1,17 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::AppResult;
 
+/// Subdirectory names for organized storage
+const DIR_ORIGINALS: &str = "originals";
+const DIR_EDITED: &str = "edited";
+const DIR_THUMBNAILS: &str = "thumbnails";
+const DIR_VIDEOS: &str = "videos";
+
 /// Ensure that the storage directories exist under the given base path.
-/// Creates: originals/, edited/, thumbnails/
-pub fn ensure_storage_dirs(base_path: &std::path::Path) -> AppResult<()> {
-    let subdirs = ["originals", "edited", "thumbnails"];
+/// Creates: originals/, edited/, thumbnails/, videos/
+pub fn ensure_storage_dirs(base_path: &Path) -> AppResult<()> {
+    let subdirs = [DIR_ORIGINALS, DIR_EDITED, DIR_THUMBNAILS, DIR_VIDEOS];
     for dir in &subdirs {
         let path = base_path.join(dir);
         if !path.exists() {
@@ -17,16 +23,215 @@ pub fn ensure_storage_dirs(base_path: &std::path::Path) -> AppResult<()> {
 }
 
 /// Get the originals directory path
-pub fn originals_dir(base_path: &std::path::Path) -> PathBuf {
-    base_path.join("originals")
+pub fn originals_dir(base_path: &Path) -> PathBuf {
+    base_path.join(DIR_ORIGINALS)
 }
 
 /// Get the edited directory path
-pub fn edited_dir(base_path: &std::path::Path) -> PathBuf {
-    base_path.join("edited")
+pub fn edited_dir(base_path: &Path) -> PathBuf {
+    base_path.join(DIR_EDITED)
 }
 
 /// Get the thumbnails directory path
-pub fn thumbnails_dir(base_path: &std::path::Path) -> PathBuf {
-    base_path.join("thumbnails")
+pub fn thumbnails_dir(base_path: &Path) -> PathBuf {
+    base_path.join(DIR_THUMBNAILS)
+}
+
+/// Get the videos directory path
+pub fn videos_dir(base_path: &Path) -> PathBuf {
+    base_path.join(DIR_VIDEOS)
+}
+
+/// Resolves storage paths for captured content.
+///
+/// Given a base save path, this struct provides deterministic path resolution
+/// for all content types: originals, edited images, thumbnails, and videos.
+#[derive(Debug, Clone)]
+pub struct StoragePathResolver {
+    base_path: PathBuf,
+}
+
+impl StoragePathResolver {
+    /// Create a new resolver with the given base save path.
+    pub fn new(base_path: PathBuf) -> Self {
+        Self { base_path }
+    }
+
+    /// Returns the root save directory.
+    pub fn base_path(&self) -> &Path {
+        &self.base_path
+    }
+
+    /// Returns the path to the originals directory.
+    pub fn originals_dir(&self) -> PathBuf {
+        originals_dir(&self.base_path)
+    }
+
+    /// Returns the path to the edited directory.
+    pub fn edited_dir(&self) -> PathBuf {
+        edited_dir(&self.base_path)
+    }
+
+    /// Returns the path to the thumbnails directory.
+    pub fn thumbnails_dir(&self) -> PathBuf {
+        thumbnails_dir(&self.base_path)
+    }
+
+    /// Returns the path to the videos directory.
+    pub fn videos_dir(&self) -> PathBuf {
+        videos_dir(&self.base_path)
+    }
+
+    /// Resolve a path for an original file with the given filename.
+    pub fn original_path(&self, filename: &str) -> PathBuf {
+        self.originals_dir().join(filename)
+    }
+
+    /// Resolve a path for an edited file with the given filename.
+    pub fn edited_path(&self, filename: &str) -> PathBuf {
+        self.edited_dir().join(filename)
+    }
+
+    /// Resolve a unique thumbnail path for the given original filename.
+    ///
+    /// The thumbnail filename is derived from the original filename,
+    /// ensuring a one-to-one mapping between originals and thumbnails.
+    /// If the original is `capture_001.png`, the thumbnail will be
+    /// `capture_001_thumb.png`.
+    pub fn thumbnail_path(&self, original_filename: &str) -> PathBuf {
+        let thumb_name = Self::thumbnail_filename(original_filename);
+        self.thumbnails_dir().join(thumb_name)
+    }
+
+    /// Resolve a path for a video file with the given filename.
+    pub fn video_path(&self, filename: &str) -> PathBuf {
+        self.videos_dir().join(filename)
+    }
+
+    /// Generate a thumbnail filename from an original filename.
+    ///
+    /// Appends `_thumb` before the extension. For example:
+    /// - `capture_001.png` → `capture_001_thumb.png`
+    /// - `screenshot.jpg` → `screenshot_thumb.jpg`
+    /// - `noext` → `noext_thumb`
+    pub fn thumbnail_filename(original_filename: &str) -> String {
+        let path = Path::new(original_filename);
+        match (path.file_stem(), path.extension()) {
+            (Some(stem), Some(ext)) => {
+                format!("{}_thumb.{}", stem.to_string_lossy(), ext.to_string_lossy())
+            }
+            (Some(stem), None) => format!("{}_thumb", stem.to_string_lossy()),
+            (None, _) => format!("{original_filename}_thumb"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_storage_dirs_creates_all() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path();
+
+        ensure_storage_dirs(base).unwrap();
+
+        assert!(base.join("originals").exists());
+        assert!(base.join("edited").exists());
+        assert!(base.join("thumbnails").exists());
+        assert!(base.join("videos").exists());
+    }
+
+    #[test]
+    fn test_ensure_storage_dirs_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path();
+
+        ensure_storage_dirs(base).unwrap();
+        ensure_storage_dirs(base).unwrap(); // Should not fail
+
+        assert!(base.join("originals").exists());
+    }
+
+    #[test]
+    fn test_resolver_originals_path() {
+        let resolver = StoragePathResolver::new(PathBuf::from("/data/AmeCapture"));
+        assert_eq!(
+            resolver.original_path("img_001.png"),
+            PathBuf::from("/data/AmeCapture/originals/img_001.png")
+        );
+    }
+
+    #[test]
+    fn test_resolver_edited_path() {
+        let resolver = StoragePathResolver::new(PathBuf::from("/data/AmeCapture"));
+        assert_eq!(
+            resolver.edited_path("img_001.png"),
+            PathBuf::from("/data/AmeCapture/edited/img_001.png")
+        );
+    }
+
+    #[test]
+    fn test_resolver_thumbnail_path() {
+        let resolver = StoragePathResolver::new(PathBuf::from("/data/AmeCapture"));
+        assert_eq!(
+            resolver.thumbnail_path("img_001.png"),
+            PathBuf::from("/data/AmeCapture/thumbnails/img_001_thumb.png")
+        );
+    }
+
+    #[test]
+    fn test_resolver_video_path() {
+        let resolver = StoragePathResolver::new(PathBuf::from("/data/AmeCapture"));
+        assert_eq!(
+            resolver.video_path("rec_001.mp4"),
+            PathBuf::from("/data/AmeCapture/videos/rec_001.mp4")
+        );
+    }
+
+    #[test]
+    fn test_thumbnail_filename_with_extension() {
+        assert_eq!(
+            StoragePathResolver::thumbnail_filename("capture_001.png"),
+            "capture_001_thumb.png"
+        );
+    }
+
+    #[test]
+    fn test_thumbnail_filename_jpg() {
+        assert_eq!(
+            StoragePathResolver::thumbnail_filename("screenshot.jpg"),
+            "screenshot_thumb.jpg"
+        );
+    }
+
+    #[test]
+    fn test_thumbnail_filename_no_extension() {
+        assert_eq!(
+            StoragePathResolver::thumbnail_filename("noext"),
+            "noext_thumb"
+        );
+    }
+
+    #[test]
+    fn test_resolver_directories() {
+        let resolver = StoragePathResolver::new(PathBuf::from("/data/AmeCapture"));
+        assert_eq!(
+            resolver.originals_dir(),
+            PathBuf::from("/data/AmeCapture/originals")
+        );
+        assert_eq!(
+            resolver.edited_dir(),
+            PathBuf::from("/data/AmeCapture/edited")
+        );
+        assert_eq!(
+            resolver.thumbnails_dir(),
+            PathBuf::from("/data/AmeCapture/thumbnails")
+        );
+        assert_eq!(
+            resolver.videos_dir(),
+            PathBuf::from("/data/AmeCapture/videos")
+        );
+    }
 }


### PR DESCRIPTION
Closes #83

## 概要

画像原本・編集済み・サムネイル・動画を保存するためのローカルディレクトリ構造を実装しました。

## 実装内容

### 1. 保存ルートの決定
- AppSettings.save_path をベースに保存ルートを決定（既存の設定を利用）
- デフォルトは ~/Pictures/AmeCapture

### 2. ディレクトリ自動作成
- \originals/\ / \dited/\ / \	humbnails/\ / \ideos/\ の4サブディレクトリをアプリ起動時に自動作成
- \storage::ensure_storage_dirs()\ を使用

### 3. パス解決サービスの実装
- **\StoragePathResolver\**: ベースパスから各ファイルパスを決定論的に解決
  - サムネイルパスは一意に決まる（例: \capture_001.png\ → \capture_001_thumb.png\）
- **\StorageService\** トレイト + **\DefaultStorageService\** 実装
- DIコンテナ（\AppState\）に統合済み

### 4. Tauri IPCコマンド
- \get_storage_paths\: 全ストレージディレクトリパスを取得
- \esolve_storage_path\: カテゴリ指定でファイルパスを解決

## 変更ファイル

| フイル | 変更内容 |
|--------|----------|
| \src-tauri/src/storage/mod.rs\ | \ideos\追加、\StoragePathResolver\追加、テスト10件 |
| \src-tauri/src/services/storage.rs\ | 新規: \StorageService\トレイト、\DefaultStorageService\、テスト2件 |
| \src-tauri/src/commands/storage.rs\ | 新規: Tauriコマンド（\get_storage_paths\, \esolve_storage_path\） |
| \src-tauri/src/app_state.rs\ | \storage_service\フィールド追加 |
| \src-tauri/src/lib.rs\ | DI登録、コマンド登録 |
| \src-tauri/Cargo.toml\ | \	empfile\ dev-dependency追加 |

## テスト結果

\\\
running 12 tests
test result: ok. 12 passed; 0 failed
\\\

## 完了条件の確認

- [x] アプリ起動時に必要なディレクトリが作成される
- [x] 原本保存と編集済み保存の置き場が分離される
- [x] サムネイルパスが一意に決まる