### PR TITLE
feat: ワークスペース詳細ペインを実装する

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,4 +1,7 @@
+use std::path::Path;
+
 use tauri::State;
+use tauri_plugin_clipboard_manager::ClipboardExt;
 
 use crate::app_state::AppState;
 use crate::error::CommandResult;
@@ -42,4 +45,65 @@ pub fn toggle_favorite(
         Ok(_) => CommandResult::success(),
         Err(e) => CommandResult::err(e.to_string()),
     }
+}
+
+#[tauri::command]
+pub fn show_item_in_folder(path: String) -> CommandResult<()> {
+    let path = Path::new(&path);
+    if !path.exists() {
+        return CommandResult::err(format!("Path does not exist: {}", path.to_string_lossy()));
+    }
+
+    let result = open_in_file_manager(path);
+    match result {
+        Ok(_) => CommandResult::success(),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn copy_image_to_clipboard(app: tauri::AppHandle, path: String) -> CommandResult<()> {
+    let path = Path::new(&path);
+    if !path.exists() {
+        return CommandResult::err(format!("File does not exist: {}", path.to_string_lossy()));
+    }
+
+    let img = match image::open(path) {
+        Ok(i) => i.to_rgba8(),
+        Err(e) => return CommandResult::err(format!("Failed to load image: {e}")),
+    };
+    let (width, height) = img.dimensions();
+    let tauri_image = tauri::image::Image::new_owned(img.into_raw(), width, height);
+
+    let clipboard = app.clipboard();
+    match clipboard.write_image(&tauri_image) {
+        Ok(_) => CommandResult::success(),
+        Err(e) => CommandResult::err(format!("Failed to write to clipboard: {e}")),
+    }
+}
+
+fn open_in_file_manager(path: &Path) -> std::io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        let path_str = path.to_string_lossy().to_string();
+        std::process::Command::new("explorer")
+            .arg(format!("/select,{path_str}"))
+            .spawn()?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let path_str = path.to_string_lossy().to_string();
+        std::process::Command::new("open")
+            .args(["-R", &path_str])
+            .spawn()?;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let parent = path.parent().unwrap_or(path);
+        std::process::Command::new("xdg-open").arg(parent).spawn()?;
+    }
+
+    Ok(())
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -48,8 +48,14 @@ pub fn toggle_favorite(
 }
 
 #[tauri::command]
-pub fn show_item_in_folder(path: String) -> CommandResult<()> {
-    let path = Path::new(&path);
+pub fn show_item_in_folder(id: String, state: State<'_, AppState>) -> CommandResult<()> {
+    let item = match state.workspace_service.get_item(&id) {
+        Ok(Some(item)) => item,
+        Ok(None) => return CommandResult::err(format!("Item not found: {id}")),
+        Err(e) => return CommandResult::err(e.to_string()),
+    };
+
+    let path = Path::new(&item.current_path);
     if !path.exists() {
         return CommandResult::err(format!("Path does not exist: {}", path.to_string_lossy()));
     }
@@ -62,8 +68,18 @@ pub fn show_item_in_folder(path: String) -> CommandResult<()> {
 }
 
 #[tauri::command]
-pub fn copy_image_to_clipboard(app: tauri::AppHandle, path: String) -> CommandResult<()> {
-    let path = Path::new(&path);
+pub fn copy_image_to_clipboard(
+    app: tauri::AppHandle,
+    id: String,
+    state: State<'_, AppState>,
+) -> CommandResult<()> {
+    let item = match state.workspace_service.get_item(&id) {
+        Ok(Some(item)) => item,
+        Ok(None) => return CommandResult::err(format!("Item not found: {id}")),
+        Err(e) => return CommandResult::err(e.to_string()),
+    };
+
+    let path = Path::new(&item.current_path);
     if !path.exists() {
         return CommandResult::err(format!("File does not exist: {}", path.to_string_lossy()));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,8 @@ pub fn run() {
             commands::workspace::delete_workspace_item,
             commands::workspace::rename_workspace_item,
             commands::workspace::toggle_favorite,
+            commands::workspace::show_item_in_folder,
+            commands::workspace::copy_image_to_clipboard,
             commands::editor::save_edit,
             commands::editor::undo,
             commands::editor::redo,

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -1,6 +1,7 @@
+import { useState, useRef, useEffect } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import type { WorkspaceItem } from '@/types';
-import { X, Star, Copy, FolderOpen, Trash2, Edit3 } from 'lucide-react';
+import { X, Star, Copy, FolderOpen, Trash2, Edit3, Check } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 
 interface DetailPanelProps {
@@ -8,15 +9,89 @@ interface DetailPanelProps {
   onClose: () => void;
   onToggleFavorite: (id: string, isFavorite: boolean) => void;
   onDelete: (id: string) => void;
+  onRename: (id: string, title: string) => void;
+  onShowInFolder: (path: string) => void;
+  onCopyToClipboard: (path: string) => void;
 }
 
-export function DetailPanel({ item, onClose, onToggleFavorite, onDelete }: DetailPanelProps) {
+export function DetailPanel({
+  item,
+  onClose,
+  onToggleFavorite,
+  onDelete,
+  onRename,
+  onShowInFolder,
+  onCopyToClipboard,
+}: DetailPanelProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(item.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setEditTitle(item.title);
+    setIsEditing(false);
+  }, [item.id, item.title]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleTitleSubmit = () => {
+    const trimmed = editTitle.trim();
+    if (trimmed && trimmed !== item.title) {
+      onRename(item.id, trimmed);
+    } else {
+      setEditTitle(item.title);
+    }
+    setIsEditing(false);
+  };
+
+  const handleTitleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleTitleSubmit();
+    } else if (e.key === 'Escape') {
+      setEditTitle(item.title);
+      setIsEditing(false);
+    }
+  };
+
   return (
     <div className="w-72 border-l border-border bg-card p-4 space-y-4 overflow-auto">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <h3 className="font-semibold text-sm truncate">{item.title}</h3>
-        <button className="p-1 rounded hover:bg-accent" onClick={onClose}>
+      <div className="flex items-center justify-between gap-2">
+        {isEditing ? (
+          <div className="flex items-center gap-1 flex-1 min-w-0">
+            <input
+              ref={inputRef}
+              className="flex-1 min-w-0 text-sm font-semibold bg-background border border-border rounded px-2 py-1 outline-none focus:border-primary"
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              onBlur={handleTitleSubmit}
+              onKeyDown={handleTitleKeyDown}
+            />
+            <button
+              className="p-1 rounded hover:bg-accent shrink-0"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleTitleSubmit();
+              }}
+            >
+              <Check className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        ) : (
+          <h3
+            className="font-semibold text-sm truncate cursor-pointer hover:text-primary"
+            onDoubleClick={() => setIsEditing(true)}
+            title="ダブルクリックでタイトルを編集"
+          >
+            {item.title}
+          </h3>
+        )}
+        <button className="p-1 rounded hover:bg-accent shrink-0" onClick={onClose}>
           <X className="w-4 h-4" />
         </button>
       </div>
@@ -50,6 +125,10 @@ export function DetailPanel({ item, onClose, onToggleFavorite, onDelete }: Detai
           <span className="text-muted-foreground">更新日時</span>
           <span>{new Date(item.updatedAt).toLocaleString('ja-JP')}</span>
         </div>
+        <div>
+          <span className="text-muted-foreground text-xs">保存先</span>
+          <p className="text-xs break-all mt-0.5">{item.currentPath}</p>
+        </div>
       </div>
 
       {/* Actions */}
@@ -58,11 +137,21 @@ export function DetailPanel({ item, onClose, onToggleFavorite, onDelete }: Detai
           <Edit3 className="w-4 h-4" />
           編集
         </button>
-        <button className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent">
+        <button
+          className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={() => onCopyToClipboard(item.currentPath)}
+          disabled={item.type !== 'image'}
+          title={
+            item.type !== 'image' ? '画像アイテムのみコピー可能です' : 'クリップボードにコピー'
+          }
+        >
           <Copy className="w-4 h-4" />
           クリップボードにコピー
         </button>
-        <button className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent">
+        <button
+          className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent"
+          onClick={() => onShowInFolder(item.currentPath)}
+        >
           <FolderOpen className="w-4 h-4" />
           保存先を開く
         </button>

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -10,8 +10,8 @@ interface DetailPanelProps {
   onToggleFavorite: (id: string, isFavorite: boolean) => void;
   onDelete: (id: string) => void;
   onRename: (id: string, title: string) => void;
-  onShowInFolder: (path: string) => void;
-  onCopyToClipboard: (path: string) => void;
+  onShowInFolder: (id: string) => void;
+  onCopyToClipboard: (id: string) => void;
 }
 
 export function DetailPanel({
@@ -139,7 +139,7 @@ export function DetailPanel({
         </button>
         <button
           className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={() => onCopyToClipboard(item.currentPath)}
+          onClick={() => onCopyToClipboard(item.id)}
           disabled={item.type !== 'image'}
           title={
             item.type !== 'image' ? '画像アイテムのみコピー可能です' : 'クリップボードにコピー'
@@ -150,7 +150,7 @@ export function DetailPanel({
         </button>
         <button
           className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent"
-          onClick={() => onShowInFolder(item.currentPath)}
+          onClick={() => onShowInFolder(item.id)}
         >
           <FolderOpen className="w-4 h-4" />
           保存先を開く

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -57,17 +57,23 @@ export function useWorkspace() {
     }
   };
 
-  const showInFolder = async (path: string) => {
+  const showInFolder = async (id: string) => {
     try {
-      await invoke<CommandResult<null>>('show_item_in_folder', { path });
+      const result = await invoke<CommandResult<null>>('show_item_in_folder', { id });
+      if (!result.success) {
+        console.error('Failed to show item in folder:', result.error);
+      }
     } catch (error) {
       console.error('Failed to show item in folder:', error);
     }
   };
 
-  const copyImageToClipboard = async (path: string) => {
+  const copyImageToClipboard = async (id: string) => {
     try {
-      await invoke<CommandResult<null>>('copy_image_to_clipboard', { path });
+      const result = await invoke<CommandResult<null>>('copy_image_to_clipboard', { id });
+      if (!result.success) {
+        console.error('Failed to copy image to clipboard:', result.error);
+      }
     } catch (error) {
       console.error('Failed to copy image to clipboard:', error);
     }

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -57,10 +57,28 @@ export function useWorkspace() {
     }
   };
 
+  const showInFolder = async (path: string) => {
+    try {
+      await invoke<CommandResult<null>>('show_item_in_folder', { path });
+    } catch (error) {
+      console.error('Failed to show item in folder:', error);
+    }
+  };
+
+  const copyImageToClipboard = async (path: string) => {
+    try {
+      await invoke<CommandResult<null>>('copy_image_to_clipboard', { path });
+    } catch (error) {
+      console.error('Failed to copy image to clipboard:', error);
+    }
+  };
+
   return {
     loadItems,
     deleteItem,
     renameItem,
     toggleFavorite,
+    showInFolder,
+    copyImageToClipboard,
   };
 }

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -17,7 +17,8 @@ export default function WorkspacePage() {
   const isLoading = useWorkspaceStore((s) => s.isLoading);
   const setSelectedItemIds = useWorkspaceStore((s) => s.setSelectedItemIds);
 
-  const { loadItems, deleteItem, toggleFavorite } = useWorkspace();
+  const { loadItems, deleteItem, toggleFavorite, renameItem, showInFolder, copyImageToClipboard } =
+    useWorkspace();
   const [showDetail, setShowDetail] = useState(false);
 
   useEffect(() => {
@@ -144,6 +145,9 @@ export default function WorkspacePage() {
             onClose={() => setShowDetail(false)}
             onToggleFavorite={toggleFavorite}
             onDelete={deleteItem}
+            onRename={renameItem}
+            onShowInFolder={showInFolder}
+            onCopyToClipboard={copyImageToClipboard}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

Closes #85

ワークスペース詳細ペインの未実装機能を追加しました。

### 実装内容

- **タイトル編集**: ダブルクリックでインライン編集可能に（Enterで確定、Escapeでキャンセル）
- **保存先パス表示**: 詳細ペインに `currentPath` を表示
- **クリップボードにコピー**: 画像をクリップボードにコピーするバックエンドコマンドを追加（画像のみ対応）
- **保存先を開く**: ファイルエクスプローラーで該当ファイルを表示するバックエンドコマンドを追加（Windows/macOS/Linux対応）

### バックエンド変更

- `commands::workspace::show_item_in_folder` - OS別ファイルマネージャー連携
- `commands::workspace::copy_image_to_clipboard` - 画像のクリップボード書き込み
- `lib.rs` - 新規コマンドの登録

### フロントエンド変更

- `DetailPanel.tsx` - タイトル編集UI、保存先表示、ボタンハンドラー実装
- `useWorkspace.ts` - `showInFolder`, `copyImageToClipboard` 関数追加
- `WorkspacePage.tsx` - DetailPanelへの新規props受け渡し

### 完了条件の確認

- [x] 一覧選択と連動して詳細が切り替わる
- [x] タイトル変更できる
- [x] 保存先フォルダを開ける