### PR TITLE
feat: complete favorites feature with filter and visible indicator

### DIFF
--- a/src-tauri/src/services/workspace.rs
+++ b/src-tauri/src/services/workspace.rs
@@ -374,4 +374,29 @@ mod tests {
         assert!(result.contains("target_1.txt"));
         assert!(Path::new(&result).exists());
     }
+
+    #[test]
+    fn test_toggle_favorite() {
+        let (service, temp_dir) = setup_service();
+        let item = sample_item_with_files("id-1", temp_dir.path());
+        service.add_item(&item).unwrap();
+
+        let found = service.get_item("id-1").unwrap().unwrap();
+        assert!(!found.is_favorite);
+
+        service.toggle_favorite("id-1", true).unwrap();
+        let found = service.get_item("id-1").unwrap().unwrap();
+        assert!(found.is_favorite);
+
+        service.toggle_favorite("id-1", false).unwrap();
+        let found = service.get_item("id-1").unwrap().unwrap();
+        assert!(!found.is_favorite);
+    }
+
+    #[test]
+    fn test_toggle_favorite_nonexistent_fails() {
+        let (service, _temp_dir) = setup_service();
+        let result = service.toggle_favorite("nonexistent", true);
+        assert!(result.is_err());
+    }
 }

--- a/src/components/ThumbnailGrid.tsx
+++ b/src/components/ThumbnailGrid.tsx
@@ -73,6 +73,13 @@ export function ThumbnailGrid({
             >
               {MEDIA_TYPE_CONFIG[item.type].label}
             </span>
+
+            {/* Favorite indicator - always visible */}
+            {item.isFavorite && (
+              <span className="absolute bottom-1 left-1 p-0.5 rounded bg-background/80">
+                <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" />
+              </span>
+            )}
           </div>
 
           {/* Info */}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -99,8 +99,9 @@ export default function WorkspacePage() {
         />
         <div className="flex items-center gap-2">
           <button
-            className={`p-1.5 rounded-md hover:bg-accent ${showFavoritesOnly ? 'bg-accent text-yellow-500' : ''}`}
+            className={`p-1.5 rounded-md hover:bg-accent ${showFavoritesOnly ? 'bg-accent text-yellow-400' : ''}`}
             title={showFavoritesOnly ? 'すべて表示' : 'お気に入りのみ表示'}
+            aria-pressed={showFavoritesOnly}
             onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
           >
             <Star

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -5,7 +5,7 @@ import { SearchBar } from '@/components/SearchBar';
 import { ThumbnailGrid } from '@/components/ThumbnailGrid';
 import { DetailPanel } from '@/components/DetailPanel';
 import { Toolbar } from '@/components/Toolbar';
-import { ImageOff, Settings } from 'lucide-react';
+import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 
 export default function WorkspacePage() {
@@ -15,7 +15,9 @@ export default function WorkspacePage() {
   const sortBy = useWorkspaceStore((s) => s.sortBy);
   const sortOrder = useWorkspaceStore((s) => s.sortOrder);
   const isLoading = useWorkspaceStore((s) => s.isLoading);
+  const showFavoritesOnly = useWorkspaceStore((s) => s.showFavoritesOnly);
   const setSelectedItemIds = useWorkspaceStore((s) => s.setSelectedItemIds);
+  const setShowFavoritesOnly = useWorkspaceStore((s) => s.setShowFavoritesOnly);
 
   const { loadItems, deleteItem, toggleFavorite, renameItem, showInFolder, copyImageToClipboard } =
     useWorkspace();
@@ -27,6 +29,10 @@ export default function WorkspacePage() {
 
   const filteredItems = useMemo(() => {
     let result = [...items];
+
+    if (showFavoritesOnly) {
+      result = result.filter((item) => item.isFavorite);
+    }
 
     if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase();
@@ -51,7 +57,7 @@ export default function WorkspacePage() {
     });
 
     return result;
-  }, [items, searchQuery, sortBy, sortOrder]);
+  }, [items, searchQuery, sortBy, sortOrder, showFavoritesOnly]);
 
   const selectedItem = useMemo(() => {
     if (selectedItemIds.length === 1) {
@@ -92,6 +98,15 @@ export default function WorkspacePage() {
           onCaptureWindow={handleCaptureWindow}
         />
         <div className="flex items-center gap-2">
+          <button
+            className={`p-1.5 rounded-md hover:bg-accent ${showFavoritesOnly ? 'bg-accent text-yellow-500' : ''}`}
+            title={showFavoritesOnly ? 'すべて表示' : 'お気に入りのみ表示'}
+            onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+          >
+            <Star
+              className={`w-4 h-4 ${showFavoritesOnly ? 'fill-yellow-400 text-yellow-400' : ''}`}
+            />
+          </button>
           <SearchBar />
           <button className="p-1.5 rounded-md hover:bg-accent" title="設定">
             <Settings className="w-4 h-4" />

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -8,6 +8,7 @@ interface WorkspaceState {
   sortBy: 'createdAt' | 'updatedAt' | 'title';
   sortOrder: 'asc' | 'desc';
   isLoading: boolean;
+  showFavoritesOnly: boolean;
 
   // Actions
   setItems: (items: WorkspaceItem[]) => void;
@@ -19,6 +20,7 @@ interface WorkspaceState {
   setSortBy: (sortBy: 'createdAt' | 'updatedAt' | 'title') => void;
   setSortOrder: (order: 'asc' | 'desc') => void;
   setLoading: (loading: boolean) => void;
+  setShowFavoritesOnly: (show: boolean) => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>((set) => ({
@@ -28,6 +30,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
   sortBy: 'createdAt',
   sortOrder: 'desc',
   isLoading: false,
+  showFavoritesOnly: false,
 
   setItems: (items) => set({ items }),
   addItem: (item) => set((state) => ({ items: [item, ...state.items] })),
@@ -45,4 +48,5 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
   setSortBy: (sortBy) => set({ sortBy }),
   setSortOrder: (order) => set({ sortOrder: order }),
   setLoading: (loading) => set({ isLoading: loading }),
+  setShowFavoritesOnly: (show) => set({ showFavoritesOnly: show }),
 }));


### PR DESCRIPTION
## Summary

- Add favorites filter toggle (★ button) in workspace header to show only favorite items
- Display persistent star indicator on favorited items in thumbnail grid (visible without hover)
- Add `showFavoritesOnly` state to workspace store with toggle action
- Add unit tests for `toggle_favorite` service method (toggle on/off and nonexistent item error)

Closes #87

## Acceptance Criteria

- [x] お気に入りON/OFFできる (already implemented: toggle in ThumbnailGrid overlay + DetailPanel)
- [x] 一覧に状態が表示される (persistent star badge on favorites + filter toggle)
- [x] 永続化される (SQLite `is_favorite` column with index)