### PR TITLE
feat: implement tag management with filtering

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -4,6 +4,7 @@ use crate::services::capture::CaptureService;
 use crate::services::editor::EditorService;
 use crate::services::settings::SettingsService;
 use crate::services::storage::StorageService;
+use crate::services::tag::TagService;
 use crate::services::thumbnail::ThumbnailService;
 use crate::services::workspace::WorkspaceService;
 
@@ -14,6 +15,7 @@ use crate::services::workspace::WorkspaceService;
 pub struct AppState {
     pub capture_service: Box<dyn CaptureService>,
     pub workspace_service: Box<dyn WorkspaceService>,
+    pub tag_service: Box<dyn TagService>,
     pub settings_service: Box<dyn SettingsService>,
     pub editor_service: Box<dyn EditorService>,
     pub thumbnail_service: Box<dyn ThumbnailService>,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod capture;
 pub mod editor;
 pub mod settings;
 pub mod storage;
+pub mod tag;
 pub mod workspace;

--- a/src-tauri/src/commands/tag.rs
+++ b/src-tauri/src/commands/tag.rs
@@ -1,0 +1,85 @@
+use tauri::State;
+
+use crate::app_state::AppState;
+use crate::error::CommandResult;
+use crate::models::tag::Tag;
+use crate::models::workspace_item::WorkspaceItem;
+
+#[tauri::command]
+pub fn get_tags(state: State<'_, AppState>) -> CommandResult<Vec<Tag>> {
+    match state.tag_service.get_all_tags() {
+        Ok(tags) => CommandResult::ok(tags),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn create_tag(name: String, state: State<'_, AppState>) -> CommandResult<Tag> {
+    match state.tag_service.create_tag(&name) {
+        Ok(tag) => CommandResult::ok(tag),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn delete_tag(id: String, state: State<'_, AppState>) -> CommandResult<()> {
+    match state.tag_service.delete_tag(&id) {
+        Ok(_) => CommandResult::success(),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn get_tags_for_item(item_id: String, state: State<'_, AppState>) -> CommandResult<Vec<Tag>> {
+    match state.tag_service.get_tags_for_item(&item_id) {
+        Ok(tags) => CommandResult::ok(tags),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn add_tag_to_item(
+    item_id: String,
+    tag_id: String,
+    state: State<'_, AppState>,
+) -> CommandResult<()> {
+    match state.tag_service.add_tag_to_item(&item_id, &tag_id) {
+        Ok(_) => CommandResult::success(),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn remove_tag_from_item(
+    item_id: String,
+    tag_id: String,
+    state: State<'_, AppState>,
+) -> CommandResult<()> {
+    match state.tag_service.remove_tag_from_item(&item_id, &tag_id) {
+        Ok(_) => CommandResult::success(),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn set_tags_for_item(
+    item_id: String,
+    tag_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> CommandResult<()> {
+    match state.tag_service.set_tags_for_item(&item_id, &tag_ids) {
+        Ok(_) => CommandResult::success(),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn get_items_by_tag(
+    tag_id: String,
+    state: State<'_, AppState>,
+) -> CommandResult<Vec<WorkspaceItem>> {
+    match state.tag_service.get_items_by_tag(&tag_id) {
+        Ok(items) => CommandResult::ok(items),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}

--- a/src-tauri/src/commands/tag.rs
+++ b/src-tauri/src/commands/tag.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use tauri::State;
 
 use crate::app_state::AppState;
@@ -80,6 +82,17 @@ pub fn get_items_by_tag(
 ) -> CommandResult<Vec<WorkspaceItem>> {
     match state.tag_service.get_items_by_tag(&tag_id) {
         Ok(items) => CommandResult::ok(items),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn get_all_tags_for_items(
+    item_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> CommandResult<HashMap<String, Vec<Tag>>> {
+    match state.tag_service.get_all_tags_for_items(&item_ids) {
+        Ok(map) => CommandResult::ok(map),
         Err(e) => CommandResult::err(e.to_string()),
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,6 +123,7 @@ pub fn run() {
             commands::tag::remove_tag_from_item,
             commands::tag::set_tags_for_item,
             commands::tag::get_items_by_tag,
+            commands::tag::get_all_tags_for_items,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,11 +18,13 @@ use crate::app_state::AppState;
 use crate::db::connection::create_connection;
 use crate::db::migrations::run_migrations;
 use crate::repositories::settings::SqliteSettingsRepository;
+use crate::repositories::tag::SqliteTagRepository;
 use crate::repositories::workspace::SqliteWorkspaceRepository;
 use crate::services::capture::DefaultCaptureService;
 use crate::services::editor::DefaultEditorService;
 use crate::services::settings::DefaultSettingsService;
 use crate::services::storage::DefaultStorageService;
+use crate::services::tag::DefaultTagService;
 use crate::services::thumbnail::DefaultThumbnailService;
 use crate::services::workspace::DefaultWorkspaceService;
 
@@ -75,12 +77,17 @@ pub fn run() {
             // === Build DI Container ===
             let workspace_repo = SqliteWorkspaceRepository::new(Arc::clone(&conn));
             let settings_repo = SqliteSettingsRepository::new(Arc::clone(&conn));
+            let tag_repo = SqliteTagRepository::new(Arc::clone(&conn));
 
             let storage_service = DefaultStorageService::new(save_path);
 
             let app_state = AppState {
                 capture_service: Box::new(DefaultCaptureService::new()),
                 workspace_service: Box::new(DefaultWorkspaceService::new(workspace_repo)),
+                tag_service: Box::new(DefaultTagService::new(
+                    tag_repo,
+                    SqliteWorkspaceRepository::new(Arc::clone(&conn)),
+                )),
                 settings_service: Box::new(DefaultSettingsService::new(settings_repo)),
                 editor_service: Box::new(DefaultEditorService::new()),
                 thumbnail_service: Box::new(DefaultThumbnailService::new()),
@@ -108,6 +115,14 @@ pub fn run() {
             commands::settings::save_settings,
             commands::storage::get_storage_paths,
             commands::storage::resolve_storage_path,
+            commands::tag::get_tags,
+            commands::tag::create_tag,
+            commands::tag::delete_tag,
+            commands::tag::get_tags_for_item,
+            commands::tag::add_tag_to_item,
+            commands::tag::remove_tag_from_item,
+            commands::tag::set_tags_for_item,
+            commands::tag::get_items_by_tag,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/repositories/tag.rs
+++ b/src-tauri/src/repositories/tag.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use rusqlite::params;
@@ -17,6 +18,10 @@ pub trait TagRepository: Send + Sync {
     fn remove_tag_from_item(&self, item_id: &str, tag_id: &str) -> AppResult<()>;
     fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()>;
     fn get_item_ids_by_tag(&self, tag_id: &str) -> AppResult<Vec<String>>;
+    fn get_all_tags_for_items(
+        &self,
+        item_ids: &[String],
+    ) -> AppResult<std::collections::HashMap<String, Vec<Tag>>>;
 }
 
 /// SQLite implementation of TagRepository
@@ -115,8 +120,7 @@ impl TagRepository for SqliteTagRepository {
                     name: row.get(1)?,
                 })
             })?
-            .filter_map(|t| t.ok())
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(tags)
     }
@@ -140,17 +144,19 @@ impl TagRepository for SqliteTagRepository {
     }
 
     fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        tx.execute(
             "DELETE FROM workspace_item_tags WHERE workspace_item_id = ?1",
             params![item_id],
         )?;
         for tag_id in tag_ids {
-            conn.execute(
+            tx.execute(
                 "INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (?1, ?2)",
                 params![item_id, tag_id],
             )?;
         }
+        tx.commit()?;
         Ok(())
     }
 
@@ -161,10 +167,52 @@ impl TagRepository for SqliteTagRepository {
 
         let ids = stmt
             .query_map(params![tag_id], |row| row.get(0))?
-            .filter_map(|r| r.ok())
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(ids)
+    }
+
+    fn get_all_tags_for_items(&self, item_ids: &[String]) -> AppResult<HashMap<String, Vec<Tag>>> {
+        if item_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let conn = self.conn.lock().unwrap();
+        let placeholders: Vec<String> = item_ids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect();
+        let sql = format!(
+            "SELECT wit.workspace_item_id, t.id, t.name
+             FROM workspace_item_tags wit
+             INNER JOIN tags t ON t.id = wit.tag_id
+             WHERE wit.workspace_item_id IN ({})
+             ORDER BY t.name",
+            placeholders.join(", ")
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> = item_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::ToSql)
+            .collect();
+        let mut map: HashMap<String, Vec<Tag>> = HashMap::new();
+        for id in item_ids {
+            map.entry(id.clone()).or_default();
+        }
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                Tag {
+                    id: row.get(1)?,
+                    name: row.get(2)?,
+                },
+            ))
+        })?;
+        for row in rows {
+            let (item_id, tag) = row?;
+            map.entry(item_id).or_default().push(tag);
+        }
+        Ok(map)
     }
 }
 

--- a/src-tauri/src/repositories/tag.rs
+++ b/src-tauri/src/repositories/tag.rs
@@ -9,8 +9,14 @@ use crate::models::tag::Tag;
 pub trait TagRepository: Send + Sync {
     fn get_all(&self) -> AppResult<Vec<Tag>>;
     fn get_by_id(&self, id: &str) -> AppResult<Option<Tag>>;
+    fn find_by_name(&self, name: &str) -> AppResult<Option<Tag>>;
     fn add(&self, tag: &Tag) -> AppResult<()>;
     fn delete(&self, id: &str) -> AppResult<()>;
+    fn get_tags_for_item(&self, item_id: &str) -> AppResult<Vec<Tag>>;
+    fn add_tag_to_item(&self, item_id: &str, tag_id: &str) -> AppResult<()>;
+    fn remove_tag_from_item(&self, item_id: &str, tag_id: &str) -> AppResult<()>;
+    fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()>;
+    fn get_item_ids_by_tag(&self, tag_id: &str) -> AppResult<Vec<String>>;
 }
 
 /// SQLite implementation of TagRepository
@@ -60,6 +66,24 @@ impl TagRepository for SqliteTagRepository {
         }
     }
 
+    fn find_by_name(&self, name: &str) -> AppResult<Option<Tag>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT id, name FROM tags WHERE name = ?1")?;
+
+        let result = stmt.query_row(params![name], |row| {
+            Ok(Tag {
+                id: row.get(0)?,
+                name: row.get(1)?,
+            })
+        });
+
+        match result {
+            Ok(tag) => Ok(Some(tag)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     fn add(&self, tag: &Tag) -> AppResult<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -73,5 +97,259 @@ impl TagRepository for SqliteTagRepository {
         let conn = self.conn.lock().unwrap();
         conn.execute("DELETE FROM tags WHERE id = ?1", params![id])?;
         Ok(())
+    }
+
+    fn get_tags_for_item(&self, item_id: &str) -> AppResult<Vec<Tag>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT t.id, t.name FROM tags t
+             INNER JOIN workspace_item_tags wit ON t.id = wit.tag_id
+             WHERE wit.workspace_item_id = ?1
+             ORDER BY t.name",
+        )?;
+
+        let tags = stmt
+            .query_map(params![item_id], |row| {
+                Ok(Tag {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                })
+            })?
+            .filter_map(|t| t.ok())
+            .collect();
+
+        Ok(tags)
+    }
+
+    fn add_tag_to_item(&self, item_id: &str, tag_id: &str) -> AppResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (?1, ?2)",
+            params![item_id, tag_id],
+        )?;
+        Ok(())
+    }
+
+    fn remove_tag_from_item(&self, item_id: &str, tag_id: &str) -> AppResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM workspace_item_tags WHERE workspace_item_id = ?1 AND tag_id = ?2",
+            params![item_id, tag_id],
+        )?;
+        Ok(())
+    }
+
+    fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM workspace_item_tags WHERE workspace_item_id = ?1",
+            params![item_id],
+        )?;
+        for tag_id in tag_ids {
+            conn.execute(
+                "INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (?1, ?2)",
+                params![item_id, tag_id],
+            )?;
+        }
+        Ok(())
+    }
+
+    fn get_item_ids_by_tag(&self, tag_id: &str) -> AppResult<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt =
+            conn.prepare("SELECT workspace_item_id FROM workspace_item_tags WHERE tag_id = ?1")?;
+
+        let ids = stmt
+            .query_map(params![tag_id], |row| row.get(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migrations::run_migrations;
+    use rusqlite::Connection;
+
+    fn setup_repo() -> SqliteTagRepository {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        run_migrations(&conn).unwrap();
+        SqliteTagRepository::new(Arc::new(Mutex::new(conn)))
+    }
+
+    fn insert_workspace_item(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO workspace_items (id, type, original_path, current_path, title, created_at, updated_at)
+             VALUES (?1, 'image', '/a.png', '/a.png', 'test', '2026-01-01', '2026-01-01')",
+            params![id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_add_and_get_all() {
+        let repo = setup_repo();
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+        repo.add(&Tag {
+            id: "t2".into(),
+            name: "tag2".into(),
+        })
+        .unwrap();
+
+        let tags = repo.get_all().unwrap();
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].name, "tag1");
+        assert_eq!(tags[1].name, "tag2");
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        let repo = setup_repo();
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+
+        let found = repo.get_by_id("t1").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "tag1");
+
+        assert!(repo.get_by_id("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let repo = setup_repo();
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+
+        let found = repo.find_by_name("tag1").unwrap();
+        assert!(found.is_some());
+
+        assert!(repo.find_by_name("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete() {
+        let repo = setup_repo();
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+        repo.delete("t1").unwrap();
+        assert!(repo.get_by_id("t1").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_add_tag_to_item_and_get() {
+        let repo = setup_repo();
+        let conn = repo.conn.lock().unwrap();
+        insert_workspace_item(&conn, "w1");
+        drop(conn);
+
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+        repo.add(&Tag {
+            id: "t2".into(),
+            name: "tag2".into(),
+        })
+        .unwrap();
+
+        repo.add_tag_to_item("w1", "t1").unwrap();
+        repo.add_tag_to_item("w1", "t2").unwrap();
+
+        let tags = repo.get_tags_for_item("w1").unwrap();
+        assert_eq!(tags.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_tag_from_item() {
+        let repo = setup_repo();
+        let conn = repo.conn.lock().unwrap();
+        insert_workspace_item(&conn, "w1");
+        drop(conn);
+
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+        repo.add_tag_to_item("w1", "t1").unwrap();
+        assert_eq!(repo.get_tags_for_item("w1").unwrap().len(), 1);
+
+        repo.remove_tag_from_item("w1", "t1").unwrap();
+        assert_eq!(repo.get_tags_for_item("w1").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_set_tags_for_item() {
+        let repo = setup_repo();
+        let conn = repo.conn.lock().unwrap();
+        insert_workspace_item(&conn, "w1");
+        drop(conn);
+
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+        repo.add(&Tag {
+            id: "t2".into(),
+            name: "tag2".into(),
+        })
+        .unwrap();
+        repo.add(&Tag {
+            id: "t3".into(),
+            name: "tag3".into(),
+        })
+        .unwrap();
+
+        repo.set_tags_for_item("w1", &["t1".into(), "t2".into()])
+            .unwrap();
+        let tags = repo.get_tags_for_item("w1").unwrap();
+        assert_eq!(tags.len(), 2);
+
+        repo.set_tags_for_item("w1", &["t3".into()]).unwrap();
+        let tags = repo.get_tags_for_item("w1").unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "tag3");
+    }
+
+    #[test]
+    fn test_get_item_ids_by_tag() {
+        let repo = setup_repo();
+        let conn = repo.conn.lock().unwrap();
+        insert_workspace_item(&conn, "w1");
+        insert_workspace_item(&conn, "w2");
+        drop(conn);
+
+        repo.add(&Tag {
+            id: "t1".into(),
+            name: "tag1".into(),
+        })
+        .unwrap();
+        repo.add_tag_to_item("w1", "t1").unwrap();
+        repo.add_tag_to_item("w2", "t1").unwrap();
+
+        let ids = repo.get_item_ids_by_tag("t1").unwrap();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"w1".to_string()));
+        assert!(ids.contains(&"w2".to_string()));
     }
 }

--- a/src-tauri/src/repositories/workspace.rs
+++ b/src-tauri/src/repositories/workspace.rs
@@ -12,6 +12,7 @@ pub trait WorkspaceRepository: Send + Sync {
     fn add(&self, item: &WorkspaceItem) -> AppResult<()>;
     fn update(&self, item: &WorkspaceItem) -> AppResult<()>;
     fn delete(&self, id: &str) -> AppResult<()>;
+    fn get_by_ids(&self, ids: &[String]) -> AppResult<Vec<WorkspaceItem>>;
 }
 
 /// SQLite implementation of WorkspaceRepository
@@ -145,6 +146,49 @@ impl WorkspaceRepository for SqliteWorkspaceRepository {
         let conn = self.conn.lock().unwrap();
         conn.execute("DELETE FROM workspace_items WHERE id = ?1", params![id])?;
         Ok(())
+    }
+
+    fn get_by_ids(&self, ids: &[String]) -> AppResult<Vec<WorkspaceItem>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.conn.lock().unwrap();
+        let placeholders: Vec<String> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect();
+        let sql = format!(
+            "SELECT id, type, original_path, current_path, thumbnail_path,
+                    title, created_at, updated_at, is_favorite, metadata_json
+             FROM workspace_items WHERE id IN ({})",
+            placeholders.join(", ")
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> =
+            ids.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+        let items = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let item_type_str: String = row.get(1)?;
+                let item_type = match item_type_str.as_str() {
+                    "video" => WorkspaceItemType::Video,
+                    _ => WorkspaceItemType::Image,
+                };
+                Ok(WorkspaceItem {
+                    id: row.get(0)?,
+                    item_type,
+                    original_path: row.get(2)?,
+                    current_path: row.get(3)?,
+                    thumbnail_path: row.get(4)?,
+                    title: row.get(5)?,
+                    created_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                    is_favorite: row.get::<_, i32>(8)? != 0,
+                    metadata_json: row.get(9)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(items)
     }
 }
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -2,5 +2,6 @@ pub mod capture;
 pub mod editor;
 pub mod settings;
 pub mod storage;
+pub mod tag;
 pub mod thumbnail;
 pub mod workspace;

--- a/src-tauri/src/services/tag.rs
+++ b/src-tauri/src/services/tag.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::error::{AppError, AppResult};
 use crate::models::tag::Tag;
 use crate::models::workspace_item::WorkspaceItem;
@@ -13,6 +15,7 @@ pub trait TagService: Send + Sync {
     fn remove_tag_from_item(&self, item_id: &str, tag_id: &str) -> AppResult<()>;
     fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()>;
     fn get_items_by_tag(&self, tag_id: &str) -> AppResult<Vec<WorkspaceItem>>;
+    fn get_all_tags_for_items(&self, item_ids: &[String]) -> AppResult<HashMap<String, Vec<Tag>>>;
 }
 
 pub struct DefaultTagService<T: TagRepository, W: WorkspaceRepository> {
@@ -96,13 +99,12 @@ impl<T: TagRepository, W: WorkspaceRepository> TagService for DefaultTagService<
     fn get_items_by_tag(&self, tag_id: &str) -> AppResult<Vec<WorkspaceItem>> {
         tracing::debug!("Fetching items for tag: {}", tag_id);
         let item_ids = self.tag_repo.get_item_ids_by_tag(tag_id)?;
-        let mut items = Vec::with_capacity(item_ids.len());
-        for id in &item_ids {
-            if let Some(item) = self.workspace_repo.get_by_id(id)? {
-                items.push(item);
-            }
-        }
-        Ok(items)
+        self.workspace_repo.get_by_ids(&item_ids)
+    }
+
+    fn get_all_tags_for_items(&self, item_ids: &[String]) -> AppResult<HashMap<String, Vec<Tag>>> {
+        tracing::debug!("Fetching tags for {} items", item_ids.len());
+        self.tag_repo.get_all_tags_for_items(item_ids)
     }
 }
 

--- a/src-tauri/src/services/tag.rs
+++ b/src-tauri/src/services/tag.rs
@@ -1,0 +1,247 @@
+use crate::error::{AppError, AppResult};
+use crate::models::tag::Tag;
+use crate::models::workspace_item::WorkspaceItem;
+use crate::repositories::tag::TagRepository;
+use crate::repositories::workspace::WorkspaceRepository;
+
+pub trait TagService: Send + Sync {
+    fn get_all_tags(&self) -> AppResult<Vec<Tag>>;
+    fn create_tag(&self, name: &str) -> AppResult<Tag>;
+    fn delete_tag(&self, id: &str) -> AppResult<()>;
+    fn get_tags_for_item(&self, item_id: &str) -> AppResult<Vec<Tag>>;
+    fn add_tag_to_item(&self, item_id: &str, tag_id: &str) -> AppResult<()>;
+    fn remove_tag_from_item(&self, item_id: &str, tag_id: &str) -> AppResult<()>;
+    fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()>;
+    fn get_items_by_tag(&self, tag_id: &str) -> AppResult<Vec<WorkspaceItem>>;
+}
+
+pub struct DefaultTagService<T: TagRepository, W: WorkspaceRepository> {
+    tag_repo: T,
+    workspace_repo: W,
+}
+
+impl<T: TagRepository, W: WorkspaceRepository> DefaultTagService<T, W> {
+    pub fn new(tag_repo: T, workspace_repo: W) -> Self {
+        Self {
+            tag_repo,
+            workspace_repo,
+        }
+    }
+}
+
+impl<T: TagRepository, W: WorkspaceRepository> TagService for DefaultTagService<T, W> {
+    fn get_all_tags(&self) -> AppResult<Vec<Tag>> {
+        tracing::debug!("Fetching all tags");
+        self.tag_repo.get_all()
+    }
+
+    fn create_tag(&self, name: &str) -> AppResult<Tag> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(AppError::Config("Tag name cannot be empty".to_string()));
+        }
+        tracing::info!("Creating tag: {}", trimmed);
+
+        if let Some(existing) = self.tag_repo.find_by_name(trimmed)? {
+            return Ok(existing);
+        }
+
+        let tag = Tag {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: trimmed.to_string(),
+        };
+        self.tag_repo.add(&tag)?;
+        Ok(tag)
+    }
+
+    fn delete_tag(&self, id: &str) -> AppResult<()> {
+        tracing::info!("Deleting tag: {}", id);
+        self.tag_repo.delete(id)
+    }
+
+    fn get_tags_for_item(&self, item_id: &str) -> AppResult<Vec<Tag>> {
+        tracing::debug!("Fetching tags for item: {}", item_id);
+        self.tag_repo.get_tags_for_item(item_id)
+    }
+
+    fn add_tag_to_item(&self, item_id: &str, tag_id: &str) -> AppResult<()> {
+        tracing::info!("Adding tag {} to item {}", tag_id, item_id);
+        self.workspace_repo
+            .get_by_id(item_id)?
+            .ok_or_else(|| AppError::NotFound(format!("Item not found: {}", item_id)))?;
+        self.tag_repo
+            .get_by_id(tag_id)?
+            .ok_or_else(|| AppError::NotFound(format!("Tag not found: {}", tag_id)))?;
+        self.tag_repo.add_tag_to_item(item_id, tag_id)
+    }
+
+    fn remove_tag_from_item(&self, item_id: &str, tag_id: &str) -> AppResult<()> {
+        tracing::info!("Removing tag {} from item {}", tag_id, item_id);
+        self.tag_repo.remove_tag_from_item(item_id, tag_id)
+    }
+
+    fn set_tags_for_item(&self, item_id: &str, tag_ids: &[String]) -> AppResult<()> {
+        tracing::info!("Setting tags for item {}: {:?}", item_id, tag_ids);
+        self.workspace_repo
+            .get_by_id(item_id)?
+            .ok_or_else(|| AppError::NotFound(format!("Item not found: {}", item_id)))?;
+        for tag_id in tag_ids {
+            self.tag_repo
+                .get_by_id(tag_id)?
+                .ok_or_else(|| AppError::NotFound(format!("Tag not found: {}", tag_id)))?;
+        }
+        self.tag_repo.set_tags_for_item(item_id, tag_ids)
+    }
+
+    fn get_items_by_tag(&self, tag_id: &str) -> AppResult<Vec<WorkspaceItem>> {
+        tracing::debug!("Fetching items for tag: {}", tag_id);
+        let item_ids = self.tag_repo.get_item_ids_by_tag(tag_id)?;
+        let mut items = Vec::with_capacity(item_ids.len());
+        for id in &item_ids {
+            if let Some(item) = self.workspace_repo.get_by_id(id)? {
+                items.push(item);
+            }
+        }
+        Ok(items)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migrations::run_migrations;
+    use crate::models::workspace_item::WorkspaceItemType;
+    use crate::repositories::tag::SqliteTagRepository;
+    use crate::repositories::workspace::SqliteWorkspaceRepository;
+    use rusqlite::Connection;
+    use std::sync::{Arc, Mutex};
+
+    fn setup_service() -> DefaultTagService<SqliteTagRepository, SqliteWorkspaceRepository> {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        run_migrations(&conn).unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        let tag_repo = SqliteTagRepository::new(Arc::clone(&conn));
+        let workspace_repo = SqliteWorkspaceRepository::new(conn);
+        DefaultTagService::new(tag_repo, workspace_repo)
+    }
+
+    fn sample_item(id: &str) -> WorkspaceItem {
+        WorkspaceItem {
+            id: id.to_string(),
+            item_type: WorkspaceItemType::Image,
+            original_path: "/original/test.png".to_string(),
+            current_path: "/current/test.png".to_string(),
+            thumbnail_path: None,
+            title: "Test Item".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            is_favorite: false,
+            metadata_json: None,
+        }
+    }
+
+    #[test]
+    fn test_create_and_get_tag() {
+        let service = setup_service();
+        let tag = service.create_tag("test-tag").unwrap();
+        assert_eq!(tag.name, "test-tag");
+        assert!(!tag.id.is_empty());
+
+        let tags = service.get_all_tags().unwrap();
+        assert_eq!(tags.len(), 1);
+    }
+
+    #[test]
+    fn test_create_tag_deduplication() {
+        let service = setup_service();
+        let tag1 = service.create_tag("tag1").unwrap();
+        let tag2 = service.create_tag("tag1").unwrap();
+        assert_eq!(tag1.id, tag2.id);
+    }
+
+    #[test]
+    fn test_create_tag_empty_name_fails() {
+        let service = setup_service();
+        assert!(service.create_tag("").is_err());
+        assert!(service.create_tag("  ").is_err());
+    }
+
+    #[test]
+    fn test_delete_tag() {
+        let service = setup_service();
+        let tag = service.create_tag("tag1").unwrap();
+        service.delete_tag(&tag.id).unwrap();
+        assert!(service.get_all_tags().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_add_and_remove_tag_from_item() {
+        let service = setup_service();
+
+        let item = sample_item("w1");
+        service.workspace_repo.add(&item).unwrap();
+
+        let tag = service.create_tag("tag1").unwrap();
+        service.add_tag_to_item("w1", &tag.id).unwrap();
+
+        let tags = service.get_tags_for_item("w1").unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "tag1");
+
+        service.remove_tag_from_item("w1", &tag.id).unwrap();
+        assert!(service.get_tags_for_item("w1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_set_tags_for_item() {
+        let service = setup_service();
+
+        let item = sample_item("w1");
+        service.workspace_repo.add(&item).unwrap();
+
+        let t1 = service.create_tag("tag1").unwrap();
+        let t2 = service.create_tag("tag2").unwrap();
+        let t3 = service.create_tag("tag3").unwrap();
+
+        service
+            .set_tags_for_item("w1", &[t1.id.clone(), t2.id.clone()])
+            .unwrap();
+        let tags = service.get_tags_for_item("w1").unwrap();
+        assert_eq!(tags.len(), 2);
+
+        service.set_tags_for_item("w1", &[t3.id.clone()]).unwrap();
+        let tags = service.get_tags_for_item("w1").unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "tag3");
+    }
+
+    #[test]
+    fn test_get_items_by_tag() {
+        let service = setup_service();
+
+        service.workspace_repo.add(&sample_item("w1")).unwrap();
+        service.workspace_repo.add(&sample_item("w2")).unwrap();
+
+        let tag = service.create_tag("tag1").unwrap();
+        service.add_tag_to_item("w1", &tag.id).unwrap();
+        service.add_tag_to_item("w2", &tag.id).unwrap();
+
+        let items = service.get_items_by_tag(&tag.id).unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn test_add_tag_to_nonexistent_item_fails() {
+        let service = setup_service();
+        let tag = service.create_tag("tag1").unwrap();
+        assert!(service.add_tag_to_item("nonexistent", &tag.id).is_err());
+    }
+
+    #[test]
+    fn test_add_nonexistent_tag_to_item_fails() {
+        let service = setup_service();
+        service.workspace_repo.add(&sample_item("w1")).unwrap();
+        assert!(service.add_tag_to_item("w1", "nonexistent").is_err());
+    }
+}

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -3,6 +3,7 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import type { WorkspaceItem } from '@/types';
 import { X, Star, Copy, FolderOpen, Trash2, Edit3, Check } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
+import { TagInput } from '@/components/TagInput';
 
 interface DetailPanelProps {
   item: WorkspaceItem;
@@ -128,6 +129,14 @@ export function DetailPanel({
         <div>
           <span className="text-muted-foreground text-xs">保存先</span>
           <p className="text-xs break-all mt-0.5">{item.currentPath}</p>
+        </div>
+      </div>
+
+      {/* Tags */}
+      <div>
+        <span className="text-muted-foreground text-xs">タグ</span>
+        <div className="mt-1">
+          <TagInput itemId={item.id} />
         </div>
       </div>
 

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { useTagStore } from '@/stores/tagStore';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useTags } from '@/hooks/useTags';
+import { X } from 'lucide-react';
+
+export function TagFilterBar() {
+  const tags = useTagStore((s) => s.tags);
+  const selectedTagIds = useWorkspaceStore((s) => s.selectedTagIds);
+  const setSelectedTagIds = useWorkspaceStore((s) => s.setSelectedTagIds);
+  const { loadTags } = useTags();
+
+  useEffect(() => {
+    loadTags();
+  }, []);
+
+  if (tags.length === 0) return null;
+
+  const toggleTag = (tagId: string) => {
+    if (selectedTagIds.includes(tagId)) {
+      setSelectedTagIds(selectedTagIds.filter((id) => id !== tagId));
+    } else {
+      setSelectedTagIds([...selectedTagIds, tagId]);
+    }
+  };
+
+  const clearTags = () => {
+    setSelectedTagIds([]);
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 px-4 py-1.5 border-b border-border bg-muted/30 overflow-x-auto">
+      <span className="text-xs text-muted-foreground whitespace-nowrap">タグ:</span>
+      {tags.map((tag) => (
+        <button
+          key={tag.id}
+          className={`px-2 py-0.5 text-xs rounded-full whitespace-nowrap transition-colors ${
+            selectedTagIds.includes(tag.id)
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted hover:bg-accent'
+          }`}
+          onClick={() => toggleTag(tag.id)}
+        >
+          {tag.name}
+        </button>
+      ))}
+      {selectedTagIds.length > 0 && (
+        <button
+          className="p-0.5 rounded hover:bg-accent"
+          onClick={clearTags}
+          title="タグフィルターをクリア"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -1,0 +1,138 @@
+import { useState, useRef, useEffect } from 'react';
+import type { Tag } from '@/types';
+import { X, Plus } from 'lucide-react';
+import { useTags } from '@/hooks/useTags';
+import { useTagStore } from '@/stores/tagStore';
+
+interface TagInputProps {
+  itemId: string;
+}
+
+export function TagInput({ itemId }: TagInputProps) {
+  const tags = useTagStore((s) => s.tags);
+  const itemTags = useTagStore((s) => s.itemTags[itemId] ?? []);
+  const [inputValue, setInputValue] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { loadTagsForItem, createTag, addTagToItem, removeTagFromItem, loadTags } = useTags();
+
+  useEffect(() => {
+    loadTagsForItem(itemId);
+  }, [itemId]);
+
+  const currentTags = itemTags;
+  const assignedTagIds = new Set(currentTags.map((t) => t.id));
+
+  const suggestions = tags.filter(
+    (t) => !assignedTagIds.has(t.id) && t.name.toLowerCase().includes(inputValue.toLowerCase()),
+  );
+
+  const handleAddTag = async (tag: Tag) => {
+    await addTagToItem(itemId, tag.id);
+    setInputValue('');
+    setShowSuggestions(false);
+  };
+
+  const handleCreateAndAdd = async () => {
+    const name = inputValue.trim();
+    if (!name) return;
+
+    const existing = tags.find((t) => t.name.toLowerCase() === name.toLowerCase());
+    if (existing) {
+      if (!assignedTagIds.has(existing.id)) {
+        await addTagToItem(itemId, existing.id);
+      }
+    } else {
+      const newTag = await createTag(name);
+      if (newTag) {
+        await addTagToItem(itemId, newTag.id);
+      }
+    }
+    setInputValue('');
+    setShowSuggestions(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (inputValue.trim()) {
+        if (suggestions.length === 1) {
+          handleAddTag(suggestions[0]);
+        } else {
+          handleCreateAndAdd();
+        }
+      }
+    } else if (e.key === 'Escape') {
+      setShowSuggestions(false);
+      setInputValue('');
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1">
+        {currentTags.map((tag) => (
+          <span
+            key={tag.id}
+            className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-primary/10 text-primary"
+          >
+            {tag.name}
+            <button
+              className="hover:text-destructive"
+              onClick={() => removeTagFromItem(itemId, tag.id)}
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="relative">
+        <div className="flex items-center gap-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              setShowSuggestions(true);
+            }}
+            onFocus={() => {
+              setShowSuggestions(true);
+              if (tags.length === 0) loadTags();
+            }}
+            onBlur={() => {
+              setTimeout(() => setShowSuggestions(false), 200);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="タグを追加..."
+            className="flex-1 px-2 py-1 text-xs border rounded bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <button
+            className="p-1 rounded hover:bg-accent"
+            onClick={handleCreateAndAdd}
+            title="タグを作成して追加"
+          >
+            <Plus className="w-3 h-3" />
+          </button>
+        </div>
+        {showSuggestions && suggestions.length > 0 && (
+          <div className="absolute z-10 left-0 right-0 mt-1 bg-background border rounded-md shadow-md max-h-32 overflow-auto">
+            {suggestions.map((tag) => (
+              <button
+                key={tag.id}
+                className="w-full text-left px-2 py-1 text-xs hover:bg-accent truncate"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleAddTag(tag);
+                }}
+              >
+                {tag.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThumbnailGrid.tsx
+++ b/src/components/ThumbnailGrid.tsx
@@ -2,6 +2,7 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import type { WorkspaceItem } from '@/types';
 import { Star, StarOff, Trash2, ImageIcon, Film } from 'lucide-react';
 import { MEDIA_TYPE_CONFIG } from '@/lib/mediaTypeConfig';
+import { useTagStore } from '@/stores/tagStore';
 
 interface ThumbnailGridProps {
   items: WorkspaceItem[];
@@ -18,6 +19,8 @@ export function ThumbnailGrid({
   onToggleFavorite,
   onDelete,
 }: ThumbnailGridProps) {
+  const itemTags = useTagStore((s) => s.itemTags);
+
   const handleClick = (id: string, e: React.MouseEvent) => {
     if (e.ctrlKey || e.metaKey) {
       const newIds = selectedIds.includes(id)
@@ -88,6 +91,18 @@ export function ThumbnailGrid({
             <p className="text-xs text-muted-foreground">
               {new Date(item.createdAt).toLocaleString('ja-JP')}
             </p>
+            {(itemTags[item.id] ?? []).length > 0 && (
+              <div className="flex flex-wrap gap-0.5 mt-1">
+                {(itemTags[item.id] ?? []).map((tag) => (
+                  <span
+                    key={tag.id}
+                    className="px-1.5 py-0 text-[10px] rounded-full bg-primary/10 text-primary"
+                  >
+                    {tag.name}
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* Actions overlay */}

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,99 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { Tag, CommandResult } from '@/types';
+import { useTagStore } from '@/stores/tagStore';
+
+export function useTags() {
+  const { setTags, addTag, removeTag, setItemTags, setLoading } = useTagStore();
+
+  const loadTags = async () => {
+    setLoading(true);
+    try {
+      const result = await invoke<CommandResult<Tag[]>>('get_tags');
+      if (result.success && result.data) {
+        setTags(result.data);
+      }
+    } catch (error) {
+      console.error('Failed to load tags:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const createTag = async (name: string): Promise<Tag | null> => {
+    try {
+      const result = await invoke<CommandResult<Tag>>('create_tag', { name });
+      if (result.success && result.data) {
+        addTag(result.data);
+        return result.data;
+      }
+    } catch (error) {
+      console.error('Failed to create tag:', error);
+    }
+    return null;
+  };
+
+  const deleteTag = async (id: string) => {
+    try {
+      const result = await invoke<CommandResult<null>>('delete_tag', { id });
+      if (result.success) {
+        removeTag(id);
+      }
+    } catch (error) {
+      console.error('Failed to delete tag:', error);
+    }
+  };
+
+  const loadTagsForItem = async (itemId: string) => {
+    try {
+      const result = await invoke<CommandResult<Tag[]>>('get_tags_for_item', { itemId });
+      if (result.success && result.data) {
+        setItemTags(itemId, result.data);
+      }
+    } catch (error) {
+      console.error('Failed to load tags for item:', error);
+    }
+  };
+
+  const addTagToItem = async (itemId: string, tagId: string) => {
+    try {
+      const result = await invoke<CommandResult<null>>('add_tag_to_item', { itemId, tagId });
+      if (result.success) {
+        await loadTagsForItem(itemId);
+      }
+    } catch (error) {
+      console.error('Failed to add tag to item:', error);
+    }
+  };
+
+  const removeTagFromItem = async (itemId: string, tagId: string) => {
+    try {
+      const result = await invoke<CommandResult<null>>('remove_tag_from_item', { itemId, tagId });
+      if (result.success) {
+        await loadTagsForItem(itemId);
+      }
+    } catch (error) {
+      console.error('Failed to remove tag from item:', error);
+    }
+  };
+
+  const setTagsForItem = async (itemId: string, tagIds: string[]) => {
+    try {
+      const result = await invoke<CommandResult<null>>('set_tags_for_item', { itemId, tagIds });
+      if (result.success) {
+        await loadTagsForItem(itemId);
+      }
+    } catch (error) {
+      console.error('Failed to set tags for item:', error);
+    }
+  };
+
+  return {
+    loadTags,
+    createTag,
+    deleteTag,
+    loadTagsForItem,
+    addTagToItem,
+    removeTagFromItem,
+    setTagsForItem,
+  };
+}

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { WorkspaceItem, CommandResult } from '@/types';
+import type { WorkspaceItem, Tag, CommandResult } from '@/types';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useTagStore } from '@/stores/tagStore';
 
 export function useWorkspace() {
   const { setItems, removeItem, updateItem, setLoading } = useWorkspaceStore();
@@ -11,6 +12,19 @@ export function useWorkspace() {
       const result = await invoke<CommandResult<WorkspaceItem[]>>('get_workspace_items');
       if (result.success && result.data) {
         setItems(result.data);
+        const tagStore = useTagStore.getState();
+        for (const item of result.data) {
+          try {
+            const tagResult = await invoke<CommandResult<Tag[]>>('get_tags_for_item', {
+              itemId: item.id,
+            });
+            if (tagResult.success && tagResult.data) {
+              tagStore.setItemTags(item.id, tagResult.data);
+            }
+          } catch {
+            // skip if tags fail for one item
+          }
+        }
       }
     } catch (error) {
       console.error('Failed to load workspace items:', error);

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -12,18 +12,20 @@ export function useWorkspace() {
       const result = await invoke<CommandResult<WorkspaceItem[]>>('get_workspace_items');
       if (result.success && result.data) {
         setItems(result.data);
-        const tagStore = useTagStore.getState();
-        for (const item of result.data) {
-          try {
-            const tagResult = await invoke<CommandResult<Tag[]>>('get_tags_for_item', {
-              itemId: item.id,
-            });
-            if (tagResult.success && tagResult.data) {
-              tagStore.setItemTags(item.id, tagResult.data);
+        try {
+          const itemIds = result.data.map((item) => item.id);
+          const tagsResult = await invoke<CommandResult<Record<string, Tag[]>>>(
+            'get_all_tags_for_items',
+            { itemIds },
+          );
+          if (tagsResult.success && tagsResult.data) {
+            const tagStore = useTagStore.getState();
+            for (const [itemId, tags] of Object.entries(tagsResult.data)) {
+              tagStore.setItemTags(itemId, tags);
             }
-          } catch {
-            // skip if tags fail for one item
           }
+        } catch {
+          // skip if tags fail
         }
       }
     } catch (error) {

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useTagStore } from '@/stores/tagStore';
 import { useWorkspace } from '@/hooks/useWorkspace';
 import { SearchBar } from '@/components/SearchBar';
 import { ThumbnailGrid } from '@/components/ThumbnailGrid';
 import { DetailPanel } from '@/components/DetailPanel';
 import { Toolbar } from '@/components/Toolbar';
+import { TagFilterBar } from '@/components/TagFilterBar';
 import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 
@@ -16,8 +18,10 @@ export default function WorkspacePage() {
   const sortOrder = useWorkspaceStore((s) => s.sortOrder);
   const isLoading = useWorkspaceStore((s) => s.isLoading);
   const showFavoritesOnly = useWorkspaceStore((s) => s.showFavoritesOnly);
+  const selectedTagIds = useWorkspaceStore((s) => s.selectedTagIds);
   const setSelectedItemIds = useWorkspaceStore((s) => s.setSelectedItemIds);
   const setShowFavoritesOnly = useWorkspaceStore((s) => s.setShowFavoritesOnly);
+  const itemTags = useTagStore((s) => s.itemTags);
 
   const { loadItems, deleteItem, toggleFavorite, renameItem, showInFolder, copyImageToClipboard } =
     useWorkspace();
@@ -32,6 +36,13 @@ export default function WorkspacePage() {
 
     if (showFavoritesOnly) {
       result = result.filter((item) => item.isFavorite);
+    }
+
+    if (selectedTagIds.length > 0) {
+      result = result.filter((item) => {
+        const itemTagIds = (itemTags[item.id] ?? []).map((t) => t.id);
+        return selectedTagIds.some((tagId) => itemTagIds.includes(tagId));
+      });
     }
 
     if (searchQuery.trim()) {
@@ -57,7 +68,7 @@ export default function WorkspacePage() {
     });
 
     return result;
-  }, [items, searchQuery, sortBy, sortOrder, showFavoritesOnly]);
+  }, [items, searchQuery, sortBy, sortOrder, showFavoritesOnly, selectedTagIds, itemTags]);
 
   const selectedItem = useMemo(() => {
     if (selectedItemIds.length === 1) {
@@ -114,6 +125,9 @@ export default function WorkspacePage() {
           </button>
         </div>
       </div>
+
+      {/* Tag filter bar */}
+      <TagFilterBar />
 
       {/* Content */}
       <div className="flex flex-1 overflow-hidden">

--- a/src/stores/tagStore.ts
+++ b/src/stores/tagStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import type { Tag } from '@/types';
+
+interface TagState {
+  tags: Tag[];
+  selectedTagIds: string[];
+  itemTags: Record<string, Tag[]>;
+  isLoading: boolean;
+
+  setTags: (tags: Tag[]) => void;
+  addTag: (tag: Tag) => void;
+  removeTag: (id: string) => void;
+  setSelectedTagIds: (ids: string[]) => void;
+  setItemTags: (itemId: string, tags: Tag[]) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+export const useTagStore = create<TagState>((set) => ({
+  tags: [],
+  selectedTagIds: [],
+  itemTags: {},
+  isLoading: false,
+
+  setTags: (tags) => set({ tags }),
+  addTag: (tag) => set((state) => ({ tags: [...state.tags, tag] })),
+  removeTag: (id) =>
+    set((state) => ({
+      tags: state.tags.filter((t) => t.id !== id),
+    })),
+  setSelectedTagIds: (ids) => set({ selectedTagIds: ids }),
+  setItemTags: (itemId, tags) =>
+    set((state) => ({
+      itemTags: { ...state.itemTags, [itemId]: tags },
+    })),
+  setLoading: (loading) => set({ isLoading: loading }),
+}));

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -9,6 +9,7 @@ interface WorkspaceState {
   sortOrder: 'asc' | 'desc';
   isLoading: boolean;
   showFavoritesOnly: boolean;
+  selectedTagIds: string[];
 
   // Actions
   setItems: (items: WorkspaceItem[]) => void;
@@ -21,6 +22,7 @@ interface WorkspaceState {
   setSortOrder: (order: 'asc' | 'desc') => void;
   setLoading: (loading: boolean) => void;
   setShowFavoritesOnly: (show: boolean) => void;
+  setSelectedTagIds: (ids: string[]) => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>((set) => ({
@@ -31,6 +33,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
   sortOrder: 'desc',
   isLoading: false,
   showFavoritesOnly: false,
+  selectedTagIds: [],
 
   setItems: (items) => set({ items }),
   addItem: (item) => set((state) => ({ items: [item, ...state.items] })),
@@ -49,4 +52,5 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
   setSortOrder: (order) => set({ sortOrder: order }),
   setLoading: (loading) => set({ isLoading: loading }),
   setShowFavoritesOnly: (show) => set({ showFavoritesOnly: show }),
+  setSelectedTagIds: (ids) => set({ selectedTagIds: ids }),
 }));


### PR DESCRIPTION
## Summary

Implement full tag management feature for workspace items:

### Backend (Rust)
- Extend `TagRepository` with item-tag association methods (`get_tags_for_item`, `add_tag_to_item`, `remove_tag_from_item`, `set_tags_for_item`, `get_item_ids_by_tag`, `find_by_name`)
- Create `TagService` with business logic (validation, deduplication on create)
- Add 8 Tauri commands for tag CRUD and item-tag management
- Wire `TagService` into `AppState` and register commands in `lib.rs`
- Add comprehensive tests (repository + service layers)

### Frontend (React/TypeScript)
- Create `tagStore` (Zustand) for tag state management
- Create `useTags` hook for Tauri IPC
- Create `TagInput` component with autocomplete suggestions for adding/removing tags on items
- Create `TagFilterBar` component for filtering workspace by tags
- Show tag badges on thumbnails in `ThumbnailGrid`
- Show tag management in `DetailPanel`
- Add `selectedTagIds` to workspace store and integrate tag filtering

### Acceptance Criteria
- [x] 複数タグを付与できる (multiple tags per item via `workspace_item_tags` join table)
- [x] タグで絞り込みできる (TagFilterBar with multi-select tag filtering)
- [x] タグが永続化される (SQLite `tags` and `workspace_item_tags` tables with foreign key cascades)

Closes #88