### PR TITLE
feat: implement full screen capture

### DIFF
--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -3,18 +3,85 @@ use tauri::State;
 use crate::app_state::AppState;
 use crate::error::CommandResult;
 use crate::models::capture::CaptureRegion;
+use crate::models::workspace_item::{WorkspaceItem, WorkspaceItemType};
 
 #[tauri::command]
 pub fn capture(
     r#type: String,
     region: Option<CaptureRegion>,
     state: State<'_, AppState>,
-) -> CommandResult<String> {
+) -> CommandResult<WorkspaceItem> {
     match r#type.as_str() {
         "fullscreen" => {
             tracing::info!("Full screen capture requested");
-            match state.capture_service.capture_full_screen() {
-                Ok(result) => CommandResult::ok(result.file_path),
+
+            if let Err(e) = state.storage_service.ensure_directories() {
+                return CommandResult::err(format!("Failed to create storage directories: {e}"));
+            }
+
+            let filename = format!(
+                "capture_{}.png",
+                chrono::Local::now().format("%Y%m%d_%H%M%S")
+            );
+
+            let original_path = state.storage_service.resolve_original_path(&filename);
+            let original_str = match original_path.to_str() {
+                Some(s) => s.to_string(),
+                None => return CommandResult::err("Invalid original path encoding"),
+            };
+
+            let capture_result = match state.capture_service.capture_full_screen(&original_str) {
+                Ok(r) => r,
+                Err(e) => return CommandResult::err(e.to_string()),
+            };
+
+            let edited_path = state.storage_service.resolve_edited_path(&filename);
+            if let Err(e) = std::fs::copy(&original_path, &edited_path) {
+                tracing::warn!("Failed to copy original to edited directory: {}", e);
+            }
+
+            let thumb_path = state.storage_service.resolve_thumbnail_path(&filename);
+            let thumb_str = match thumb_path.to_str() {
+                Some(s) => s.to_string(),
+                None => return CommandResult::err("Invalid thumbnail path encoding"),
+            };
+
+            if let Err(e) = state
+                .thumbnail_service
+                .generate_thumbnail(&original_str, &thumb_str)
+            {
+                tracing::warn!("Failed to generate thumbnail: {}", e);
+            }
+
+            let now = chrono::Utc::now().to_rfc3339();
+            let title = format!(
+                "Capture {}",
+                chrono::Local::now().format("%Y/%m/%d %H:%M:%S")
+            );
+
+            let item = WorkspaceItem {
+                id: uuid::Uuid::new_v4().to_string(),
+                item_type: WorkspaceItemType::Image,
+                original_path: original_str,
+                current_path: edited_path.to_string_lossy().to_string(),
+                thumbnail_path: Some(thumb_str),
+                title,
+                created_at: now.clone(),
+                updated_at: now,
+                is_favorite: false,
+                metadata_json: None,
+            };
+
+            match state.workspace_service.add_item(&item) {
+                Ok(()) => {
+                    tracing::info!(
+                        "Full screen capture saved: {} ({}x{})",
+                        item.id,
+                        capture_result.width,
+                        capture_result.height
+                    );
+                    CommandResult::ok(item)
+                }
                 Err(e) => CommandResult::err(e.to_string()),
             }
         }
@@ -27,17 +94,13 @@ pub fn capture(
                     r.width,
                     r.height
                 );
-                match state.capture_service.capture_region(&r) {
-                    Ok(result) => CommandResult::ok(result.file_path),
-                    Err(e) => CommandResult::err(e.to_string()),
-                }
+                CommandResult::err("Region capture not yet implemented")
             } else {
                 CommandResult::err("Region not specified")
             }
         }
         "window" => {
             tracing::info!("Window capture requested");
-            // Window capture requires hwnd, will be handled in future implementation
             CommandResult::err("Window capture not yet implemented")
         }
         _ => CommandResult::err(format!("Unknown capture type: {}", r#type)),

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -36,8 +36,15 @@ pub fn capture(
             };
 
             let edited_path = state.storage_service.resolve_edited_path(&filename);
+            let edited_str = match edited_path.to_str() {
+                Some(s) => s.to_string(),
+                None => return CommandResult::err("Invalid edited path encoding"),
+            };
+
             if let Err(e) = std::fs::copy(&original_path, &edited_path) {
-                tracing::warn!("Failed to copy original to edited directory: {}", e);
+                return CommandResult::err(format!(
+                    "Failed to copy original to edited directory: {e}"
+                ));
             }
 
             let thumb_path = state.storage_service.resolve_thumbnail_path(&filename);
@@ -50,7 +57,7 @@ pub fn capture(
                 .thumbnail_service
                 .generate_thumbnail(&original_str, &thumb_str)
             {
-                tracing::warn!("Failed to generate thumbnail: {}", e);
+                return CommandResult::err(format!("Failed to generate thumbnail: {e}"));
             }
 
             let now = chrono::Utc::now().to_rfc3339();
@@ -63,7 +70,7 @@ pub fn capture(
                 id: uuid::Uuid::new_v4().to_string(),
                 item_type: WorkspaceItemType::Image,
                 original_path: original_str,
-                current_path: edited_path.to_string_lossy().to_string(),
+                current_path: edited_str,
                 thumbnail_path: Some(thumb_str),
                 title,
                 created_at: now.clone(),

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -68,6 +68,80 @@ impl CaptureService for DefaultCaptureService {
 }
 
 #[cfg(target_os = "windows")]
+mod gdi_guard {
+    use windows::Win32::Graphics::Gdi::{
+        DeleteDC, DeleteObject, ReleaseDC, SelectObject, HBITMAP, HDC, HGDIOBJ,
+    };
+
+    pub struct ScreenDcGuard {
+        dc: HDC,
+        released: bool,
+    }
+
+    impl ScreenDcGuard {
+        pub fn new(dc: HDC) -> Self {
+            Self {
+                dc,
+                released: false,
+            }
+        }
+
+        pub fn get(&self) -> HDC {
+            self.dc
+        }
+
+        pub fn release(mut self) {
+            unsafe {
+                let _ = ReleaseDC(None, self.dc);
+            }
+            self.released = true;
+        }
+    }
+
+    impl Drop for ScreenDcGuard {
+        fn drop(&mut self) {
+            if !self.released {
+                unsafe {
+                    let _ = ReleaseDC(None, self.dc);
+                }
+            }
+        }
+    }
+
+    pub struct GdiCleanup {
+        mem_dc: Option<HDC>,
+        bitmap: Option<HBITMAP>,
+        old_obj: Option<HGDIOBJ>,
+    }
+
+    impl GdiCleanup {
+        pub fn new(mem_dc: HDC, bitmap: HBITMAP, old_obj: HGDIOBJ) -> Self {
+            Self {
+                mem_dc: Some(mem_dc),
+                bitmap: Some(bitmap),
+                old_obj: Some(old_obj),
+            }
+        }
+    }
+
+    impl Drop for GdiCleanup {
+        fn drop(&mut self) {
+            unsafe {
+                if let (Some(dc), Some(old)) = (self.mem_dc, self.old_obj) {
+                    let _ = SelectObject(dc, old);
+                }
+                if let Some(bmp) = self.bitmap.take() {
+                    let _ = DeleteObject(bmp.into());
+                }
+                if let Some(dc) = self.mem_dc.take() {
+                    let _ = DeleteDC(dc);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
 fn capture_screen(save_path: &str) -> AppResult<CaptureResult> {
     use windows::Win32::Graphics::Gdi::*;
     use windows::Win32::UI::WindowsAndMessaging::*;
@@ -78,21 +152,31 @@ fn capture_screen(save_path: &str) -> AppResult<CaptureResult> {
     }
 
     unsafe {
-        let screen_dc = GetDC(None);
+        let screen_dc = gdi_guard::ScreenDcGuard::new(GetDC(None));
         let width = GetSystemMetrics(SM_CXSCREEN);
         let height = GetSystemMetrics(SM_CYSCREEN);
 
         if width <= 0 || height <= 0 {
-            let _ = ReleaseDC(None, screen_dc);
             return Err(AppError::Capture("Invalid screen dimensions".into()));
         }
 
-        let mem_dc = CreateCompatibleDC(Some(screen_dc));
-        let bitmap = CreateCompatibleBitmap(screen_dc, width, height);
-        let _old = SelectObject(mem_dc, bitmap.into());
+        let mem_dc = CreateCompatibleDC(Some(screen_dc.get()));
+        let bitmap = CreateCompatibleBitmap(screen_dc.get(), width, height);
+        let old = SelectObject(mem_dc, bitmap.into());
 
-        if let Err(e) = BitBlt(mem_dc, 0, 0, width, height, Some(screen_dc), 0, 0, SRCCOPY) {
-            let _ = ReleaseDC(None, screen_dc);
+        let _gdi = gdi_guard::GdiCleanup::new(mem_dc, bitmap, old);
+
+        if let Err(e) = BitBlt(
+            mem_dc,
+            0,
+            0,
+            width,
+            height,
+            Some(screen_dc.get()),
+            0,
+            0,
+            SRCCOPY,
+        ) {
             return Err(AppError::Capture(format!("BitBlt failed: {e}")));
         }
 
@@ -117,7 +201,6 @@ fn capture_screen(save_path: &str) -> AppResult<CaptureResult> {
         );
 
         if scan_lines == 0 {
-            let _ = ReleaseDC(None, screen_dc);
             return Err(AppError::Capture("GetDIBits returned 0 scan lines".into()));
         }
 
@@ -125,26 +208,15 @@ fn capture_screen(save_path: &str) -> AppResult<CaptureResult> {
             chunk.swap(0, 2);
         }
 
-        let img = match image::RgbaImage::from_raw(width as u32, height as u32, pixels) {
-            Some(i) => i,
-            None => {
-                let _ = ReleaseDC(None, screen_dc);
-                return Err(AppError::Capture(
-                    "Failed to create image from captured pixels".into(),
-                ));
-            }
-        };
+        let img =
+            image::RgbaImage::from_raw(width as u32, height as u32, pixels).ok_or_else(|| {
+                AppError::Capture("Failed to create image from captured pixels".into())
+            })?;
 
-        if let Err(e) = img.save_with_format(save, image::ImageFormat::Png) {
-            let _ = ReleaseDC(None, screen_dc);
-            return Err(AppError::Capture(format!(
-                "Failed to save captured image: {e}"
-            )));
-        }
+        img.save_with_format(save, image::ImageFormat::Png)
+            .map_err(|e| AppError::Capture(format!("Failed to save captured image: {e}")))?;
 
-        let _ = DeleteObject(bitmap.into());
-        let _ = DeleteDC(mem_dc);
-        let _ = ReleaseDC(None, screen_dc);
+        screen_dc.release();
 
         Ok(CaptureResult {
             file_path: save_path.to_string(),

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -1,14 +1,12 @@
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::models::capture::{CaptureRegion, CaptureResult};
 
-/// Service trait for capture operations
 pub trait CaptureService: Send + Sync {
-    fn capture_full_screen(&self) -> AppResult<CaptureResult>;
-    fn capture_region(&self, region: &CaptureRegion) -> AppResult<CaptureResult>;
-    fn capture_window(&self, hwnd: isize) -> AppResult<CaptureResult>;
+    fn capture_full_screen(&self, save_path: &str) -> AppResult<CaptureResult>;
+    fn capture_region(&self, region: &CaptureRegion, save_path: &str) -> AppResult<CaptureResult>;
+    fn capture_window(&self, hwnd: isize, save_path: &str) -> AppResult<CaptureResult>;
 }
 
-/// Default capture service (placeholder for actual implementation)
 pub struct DefaultCaptureService;
 
 impl DefaultCaptureService {
@@ -17,34 +15,141 @@ impl DefaultCaptureService {
     }
 }
 
+#[cfg(target_os = "windows")]
 impl CaptureService for DefaultCaptureService {
-    fn capture_full_screen(&self) -> AppResult<CaptureResult> {
-        tracing::info!("Full screen capture requested (not yet implemented)");
-        Err(crate::error::AppError::Capture(
-            "Full screen capture not yet implemented".into(),
-        ))
+    fn capture_full_screen(&self, save_path: &str) -> AppResult<CaptureResult> {
+        capture_screen(save_path)
     }
 
-    fn capture_region(&self, region: &CaptureRegion) -> AppResult<CaptureResult> {
+    fn capture_region(&self, region: &CaptureRegion, _save_path: &str) -> AppResult<CaptureResult> {
         tracing::info!(
-            "Region capture requested: x={}, y={}, width={}, height={} (not yet implemented)",
+            "Region capture requested: x={}, y={}, width={}, height={}",
             region.x,
             region.y,
             region.width,
             region.height
         );
-        Err(crate::error::AppError::Capture(
+        Err(AppError::Capture(
             "Region capture not yet implemented".into(),
         ))
     }
 
-    fn capture_window(&self, hwnd: isize) -> AppResult<CaptureResult> {
-        tracing::info!(
-            "Window capture requested for hwnd={} (not yet implemented)",
-            hwnd
-        );
-        Err(crate::error::AppError::Capture(
+    fn capture_window(&self, hwnd: isize, _save_path: &str) -> AppResult<CaptureResult> {
+        tracing::info!("Window capture requested for hwnd={}", hwnd);
+        Err(AppError::Capture(
             "Window capture not yet implemented".into(),
         ))
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl CaptureService for DefaultCaptureService {
+    fn capture_full_screen(&self, _save_path: &str) -> AppResult<CaptureResult> {
+        Err(AppError::Capture(
+            "Full screen capture is only supported on Windows".into(),
+        ))
+    }
+
+    fn capture_region(
+        &self,
+        _region: &CaptureRegion,
+        _save_path: &str,
+    ) -> AppResult<CaptureResult> {
+        Err(AppError::Capture(
+            "Region capture is only supported on Windows".into(),
+        ))
+    }
+
+    fn capture_window(&self, _hwnd: isize, _save_path: &str) -> AppResult<CaptureResult> {
+        Err(AppError::Capture(
+            "Window capture is only supported on Windows".into(),
+        ))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn capture_screen(save_path: &str) -> AppResult<CaptureResult> {
+    use windows::Win32::Graphics::Gdi::*;
+    use windows::Win32::UI::WindowsAndMessaging::*;
+
+    let save = std::path::Path::new(save_path);
+    if let Some(parent) = save.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    unsafe {
+        let screen_dc = GetDC(None);
+        let width = GetSystemMetrics(SM_CXSCREEN);
+        let height = GetSystemMetrics(SM_CYSCREEN);
+
+        if width <= 0 || height <= 0 {
+            let _ = ReleaseDC(None, screen_dc);
+            return Err(AppError::Capture("Invalid screen dimensions".into()));
+        }
+
+        let mem_dc = CreateCompatibleDC(Some(screen_dc));
+        let bitmap = CreateCompatibleBitmap(screen_dc, width, height);
+        let _old = SelectObject(mem_dc, bitmap.into());
+
+        if let Err(e) = BitBlt(mem_dc, 0, 0, width, height, Some(screen_dc), 0, 0, SRCCOPY) {
+            let _ = ReleaseDC(None, screen_dc);
+            return Err(AppError::Capture(format!("BitBlt failed: {e}")));
+        }
+
+        let mut bmi: BITMAPINFO = std::mem::zeroed();
+        bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
+        bmi.bmiHeader.biWidth = width;
+        bmi.bmiHeader.biHeight = -height;
+        bmi.bmiHeader.biPlanes = 1;
+        bmi.bmiHeader.biBitCount = 32;
+
+        let buf_size = (width as usize) * (height as usize) * 4;
+        let mut pixels = vec![0u8; buf_size];
+
+        let scan_lines = GetDIBits(
+            mem_dc,
+            bitmap,
+            0,
+            height as u32,
+            Some(pixels.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+
+        if scan_lines == 0 {
+            let _ = ReleaseDC(None, screen_dc);
+            return Err(AppError::Capture("GetDIBits returned 0 scan lines".into()));
+        }
+
+        for chunk in pixels.chunks_exact_mut(4) {
+            chunk.swap(0, 2);
+        }
+
+        let img = match image::RgbaImage::from_raw(width as u32, height as u32, pixels) {
+            Some(i) => i,
+            None => {
+                let _ = ReleaseDC(None, screen_dc);
+                return Err(AppError::Capture(
+                    "Failed to create image from captured pixels".into(),
+                ));
+            }
+        };
+
+        if let Err(e) = img.save_with_format(save, image::ImageFormat::Png) {
+            let _ = ReleaseDC(None, screen_dc);
+            return Err(AppError::Capture(format!(
+                "Failed to save captured image: {e}"
+            )));
+        }
+
+        let _ = DeleteObject(bitmap.into());
+        let _ = DeleteDC(mem_dc);
+        let _ = ReleaseDC(None, screen_dc);
+
+        Ok(CaptureResult {
+            file_path: save_path.to_string(),
+            width: width as u32,
+            height: height as u32,
+        })
     }
 }

--- a/src-tauri/src/services/thumbnail.rs
+++ b/src-tauri/src/services/thumbnail.rs
@@ -1,11 +1,9 @@
 use crate::error::AppResult;
 
-/// Service trait for thumbnail generation
 pub trait ThumbnailService: Send + Sync {
-    fn generate_thumbnail(&self, source_path: &str) -> AppResult<String>;
+    fn generate_thumbnail(&self, source_path: &str, thumbnail_path: &str) -> AppResult<String>;
 }
 
-/// Default thumbnail service (placeholder)
 pub struct DefaultThumbnailService;
 
 impl DefaultThumbnailService {
@@ -15,13 +13,17 @@ impl DefaultThumbnailService {
 }
 
 impl ThumbnailService for DefaultThumbnailService {
-    fn generate_thumbnail(&self, source_path: &str) -> AppResult<String> {
-        tracing::info!(
-            "Thumbnail generation requested for: {} (not yet implemented)",
-            source_path
-        );
-        Err(crate::error::AppError::Capture(
-            "Thumbnail generation not yet implemented".into(),
-        ))
+    fn generate_thumbnail(&self, source_path: &str, thumbnail_path: &str) -> AppResult<String> {
+        let img = image::open(source_path)?;
+        let thumbnail = img.thumbnail(256, 256);
+
+        let path = std::path::Path::new(thumbnail_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        thumbnail.save(path)?;
+
+        Ok(thumbnail_path.to_string())
     }
 }

--- a/src/hooks/useCapture.ts
+++ b/src/hooks/useCapture.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { CaptureRegion, CaptureType, CommandResult } from '@/types';
+import type { CaptureRegion, CaptureType, CommandResult, WorkspaceItem } from '@/types';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 export function useCapture() {
@@ -7,13 +7,12 @@ export function useCapture() {
 
   const capture = async (type: CaptureType, region?: CaptureRegion) => {
     try {
-      const result = await invoke<CommandResult<string>>('capture', {
+      const result = await invoke<CommandResult<WorkspaceItem>>('capture', {
         type,
         region: region ?? null,
       });
       if (result.success && result.data) {
-        // TODO: Fetch the full WorkspaceItem from backend after capture
-        console.log('Capture saved:', result.data);
+        addItem(result.data);
       }
       return result;
     } catch (error) {

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useTagStore } from '@/stores/tagStore';
 import { useWorkspace } from '@/hooks/useWorkspace';
+import { useCapture } from '@/hooks/useCapture';
 import { SearchBar } from '@/components/SearchBar';
 import { ThumbnailGrid } from '@/components/ThumbnailGrid';
 import { DetailPanel } from '@/components/DetailPanel';
@@ -25,6 +26,7 @@ export default function WorkspacePage() {
 
   const { loadItems, deleteItem, toggleFavorite, renameItem, showInFolder, copyImageToClipboard } =
     useWorkspace();
+  const { captureFullscreen } = useCapture();
   const [showDetail, setShowDetail] = useState(false);
 
   useEffect(() => {
@@ -82,8 +84,8 @@ export default function WorkspacePage() {
     setShowDetail(ids.length === 1);
   };
 
-  const handleCaptureFullscreen = () => {
-    // TODO: implement fullscreen capture
+  const handleCaptureFullscreen = async () => {
+    await captureFullscreen();
   };
 
   const handleCaptureRegion = (_region: {


### PR DESCRIPTION
## Summary

Closes #89

- Implement full screen capture using Windows GDI API (BitBlt + GetDIBits)
- Save original image to `originals/` storage directory
- Copy to `edited/` directory as `current_path`
- Generate 256x256 thumbnail using the `image` crate
- Register capture as `WorkspaceItem` in SQLite database
- Update capture command to return `WorkspaceItem` instead of file path string
- Wire up fullscreen capture button in `WorkspacePage` frontend
- Auto-add captured item to workspace store via `useCapture` hook

## Implementation Details

### Backend (Rust)
- **`services/capture.rs`**: Implemented `capture_full_screen()` using Windows GDI — captures screen via `GetDC`, `BitBlt`, and `GetDIBits`, converts BGRA→RGBA, saves as PNG
- **`services/thumbnail.rs`**: Implemented `generate_thumbnail()` using `image::DynamicImage::thumbnail()` for 256x256 resize
- **`commands/capture.rs`**: Orchestrate full pipeline — capture → copy to edited → generate thumbnail → create WorkspaceItem → register in DB → return item

### Frontend (TypeScript)
- **`hooks/useCapture.ts`**: Updated return type from `string` to `WorkspaceItem`, auto-adds to store
- **`pages/WorkspacePage.tsx`**: Connected fullscreen capture button to `captureFullscreen()` handler

## Acceptance Criteria

- [x] Full screen image is saved
- [x] Automatically added to the list (workspace store + database)
- [x] Thumbnail is generated

## Test Results

- `cargo test`: 61 tests passed, 0 failed
- `cargo clippy`: No new warnings (pre-existing dead_code warnings only)