### PR TITLE
feat: 指定領域キャプチャを実装する

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tracing-appender = "0.2"
 tracing-log = "0.2"
 dirs = "6"
 anyhow = "1"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -162,6 +162,8 @@ pub fn prepare_region_capture(
         tracing::warn!("Failed to minimize window: {}", e);
     }
 
+    // TODO: ウィンドウの最小化完了イベントを待機する実装を検討する。
+    // 現状は、OSやマシンスペックによるアニメーション等の完了ラグを吸収するため、200ms待機している。
     std::thread::sleep(Duration::from_millis(200));
 
     let temp_dir = std::env::temp_dir();
@@ -302,6 +304,7 @@ pub fn finalize_region_capture(
         .thumbnail_service
         .generate_thumbnail(&original_str, &thumb_str)
     {
+        let _ = std::fs::remove_file(&source_path);
         return CommandResult::err(format!("Failed to generate thumbnail: {e}"));
     }
 

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -1,8 +1,11 @@
+use std::time::Duration;
+
+use tauri::Manager;
 use tauri::State;
 
 use crate::app_state::AppState;
 use crate::error::CommandResult;
-use crate::models::capture::CaptureRegion;
+use crate::models::capture::{CaptureRegion, RegionCaptureInfo};
 use crate::models::workspace_item::{WorkspaceItem, WorkspaceItemType};
 
 #[tauri::command]
@@ -112,4 +115,179 @@ pub fn capture(
         }
         _ => CommandResult::err(format!("Unknown capture type: {}", r#type)),
     }
+}
+
+#[tauri::command]
+pub fn prepare_region_capture(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> CommandResult<RegionCaptureInfo> {
+    tracing::info!("Preparing region capture");
+
+    let window = match app.get_webview_window("main") {
+        Some(w) => w,
+        None => return CommandResult::err("Main window not found"),
+    };
+
+    if let Err(e) = window.minimize() {
+        tracing::warn!("Failed to minimize window: {}", e);
+    }
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let temp_dir = std::env::temp_dir();
+    let temp_path = temp_dir.join(format!("amecapture_region_{}.png", uuid::Uuid::new_v4()));
+    let temp_str = match temp_path.to_str() {
+        Some(s) => s.to_string(),
+        None => return CommandResult::err("Invalid temp path encoding"),
+    };
+
+    let capture_result = match state.capture_service.capture_full_screen(&temp_str) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = window.unminimize();
+            let _ = window.set_focus();
+            return CommandResult::err(e.to_string());
+        }
+    };
+
+    if let Err(e) = window.unminimize() {
+        tracing::warn!("Failed to unminimize window: {}", e);
+    }
+    if let Err(e) = window.set_focus() {
+        tracing::warn!("Failed to focus window: {}", e);
+    }
+
+    tracing::info!(
+        "Region capture prepared: {} ({}x{})",
+        temp_str,
+        capture_result.width,
+        capture_result.height
+    );
+
+    CommandResult::ok(RegionCaptureInfo {
+        temp_path: temp_str,
+        screen_width: capture_result.width,
+        screen_height: capture_result.height,
+    })
+}
+
+#[tauri::command]
+pub fn finalize_region_capture(
+    source_path: String,
+    region: CaptureRegion,
+    state: State<'_, AppState>,
+) -> CommandResult<WorkspaceItem> {
+    tracing::info!(
+        "Finalizing region capture: x={}, y={}, width={}, height={}",
+        region.x,
+        region.y,
+        region.width,
+        region.height
+    );
+
+    if let Err(e) = state.storage_service.ensure_directories() {
+        return CommandResult::err(format!("Failed to create storage directories: {e}"));
+    }
+
+    let source = std::path::Path::new(&source_path);
+    if !source.exists() {
+        return CommandResult::err("Source screenshot file not found");
+    }
+
+    let img = match image::open(source) {
+        Ok(i) => i,
+        Err(e) => return CommandResult::err(format!("Failed to open source image: {e}")),
+    };
+
+    let x = (region.x.max(0) as u32).min(img.width().saturating_sub(1));
+    let y = (region.y.max(0) as u32).min(img.height().saturating_sub(1));
+    let max_w = img.width().saturating_sub(x);
+    let max_h = img.height().saturating_sub(y);
+    let w = region.width.min(max_w);
+    let h = region.height.min(max_h);
+
+    if w == 0 || h == 0 {
+        let _ = std::fs::remove_file(&source_path);
+        return CommandResult::err("Selected region is too small");
+    }
+
+    let cropped = img.crop_imm(x, y, w, h);
+
+    let filename = format!(
+        "capture_{}.png",
+        chrono::Local::now().format("%Y%m%d_%H%M%S")
+    );
+
+    let original_path = state.storage_service.resolve_original_path(&filename);
+    let original_str = match original_path.to_str() {
+        Some(s) => s.to_string(),
+        None => return CommandResult::err("Invalid original path encoding"),
+    };
+
+    if let Err(e) = cropped.save_with_format(&original_path, image::ImageFormat::Png) {
+        let _ = std::fs::remove_file(&source_path);
+        return CommandResult::err(format!("Failed to save cropped image: {e}"));
+    }
+
+    let edited_path = state.storage_service.resolve_edited_path(&filename);
+    let edited_str = match edited_path.to_str() {
+        Some(s) => s.to_string(),
+        None => return CommandResult::err("Invalid edited path encoding"),
+    };
+
+    if let Err(e) = std::fs::copy(&original_path, &edited_path) {
+        return CommandResult::err(format!("Failed to copy original to edited directory: {e}"));
+    }
+
+    let thumb_path = state.storage_service.resolve_thumbnail_path(&filename);
+    let thumb_str = match thumb_path.to_str() {
+        Some(s) => s.to_string(),
+        None => return CommandResult::err("Invalid thumbnail path encoding"),
+    };
+
+    if let Err(e) = state
+        .thumbnail_service
+        .generate_thumbnail(&original_str, &thumb_str)
+    {
+        return CommandResult::err(format!("Failed to generate thumbnail: {e}"));
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let title = format!(
+        "Region Capture {}",
+        chrono::Local::now().format("%Y/%m/%d %H:%M:%S")
+    );
+
+    let item = WorkspaceItem {
+        id: uuid::Uuid::new_v4().to_string(),
+        item_type: WorkspaceItemType::Image,
+        original_path: original_str,
+        current_path: edited_str,
+        thumbnail_path: Some(thumb_str),
+        title,
+        created_at: now.clone(),
+        updated_at: now,
+        is_favorite: false,
+        metadata_json: None,
+    };
+
+    match state.workspace_service.add_item(&item) {
+        Ok(()) => {
+            tracing::info!("Region capture saved: {} ({}x{})", item.id, w, h);
+            let _ = std::fs::remove_file(&source_path);
+            CommandResult::ok(item)
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&source_path);
+            CommandResult::err(e.to_string())
+        }
+    }
+}
+
+#[tauri::command]
+pub fn cancel_region_capture(source_path: String) -> CommandResult<()> {
+    tracing::info!("Cancelling region capture");
+    let _ = std::fs::remove_file(&source_path);
+    CommandResult::success()
 }

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -287,17 +287,24 @@ pub fn finalize_region_capture(
     let edited_path = state.storage_service.resolve_edited_path(&filename);
     let edited_str = match edited_path.to_str() {
         Some(s) => s.to_string(),
-        None => return CommandResult::err("Invalid edited path encoding"),
+        None => {
+            let _ = std::fs::remove_file(&source_path);
+            return CommandResult::err("Invalid edited path encoding");
+        }
     };
 
     if let Err(e) = std::fs::copy(&original_path, &edited_path) {
+        let _ = std::fs::remove_file(&source_path);
         return CommandResult::err(format!("Failed to copy original to edited directory: {e}"));
     }
 
     let thumb_path = state.storage_service.resolve_thumbnail_path(&filename);
     let thumb_str = match thumb_path.to_str() {
         Some(s) => s.to_string(),
-        None => return CommandResult::err("Invalid thumbnail path encoding"),
+        None => {
+            let _ = std::fs::remove_file(&source_path);
+            return CommandResult::err("Invalid thumbnail path encoding");
+        }
     };
 
     if let Err(e) = state

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use tauri::Manager;
@@ -7,6 +8,34 @@ use crate::app_state::AppState;
 use crate::error::CommandResult;
 use crate::models::capture::{CaptureRegion, RegionCaptureInfo};
 use crate::models::workspace_item::{WorkspaceItem, WorkspaceItemType};
+
+fn validate_temp_path(source_path: &str) -> Result<(), String> {
+    let path = Path::new(source_path);
+
+    let temp_dir = std::env::temp_dir();
+    let canonical_source = path
+        .canonicalize()
+        .map_err(|_| "Invalid source path".to_string())?;
+    let canonical_temp = temp_dir
+        .canonicalize()
+        .map_err(|_| "Cannot resolve temp directory".to_string())?;
+
+    if !canonical_source.starts_with(&canonical_temp) {
+        return Err("Source path is outside the temp directory".to_string());
+    }
+
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "Invalid file name".to_string())?
+        .to_str()
+        .ok_or_else(|| "Invalid file name encoding".to_string())?;
+
+    if !file_name.starts_with("amecapture_region_") || !file_name.ends_with(".png") {
+        return Err("Invalid temp file name pattern".to_string());
+    }
+
+    Ok(())
+}
 
 #[tauri::command]
 pub fn capture(
@@ -158,6 +187,18 @@ pub fn prepare_region_capture(
         tracing::warn!("Failed to focus window: {}", e);
     }
 
+    let image_bytes = match std::fs::read(&temp_path) {
+        Ok(b) => b,
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_path);
+            return CommandResult::err(format!("Failed to read temp image: {e}"));
+        }
+    };
+    let image_data_uri = format!(
+        "data:image/png;base64,{}",
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &image_bytes)
+    );
+
     tracing::info!(
         "Region capture prepared: {} ({}x{})",
         temp_str,
@@ -169,6 +210,7 @@ pub fn prepare_region_capture(
         temp_path: temp_str,
         screen_width: capture_result.width,
         screen_height: capture_result.height,
+        image_data_uri,
     })
 }
 
@@ -186,18 +228,25 @@ pub fn finalize_region_capture(
         region.height
     );
 
+    if let Err(e) = validate_temp_path(&source_path) {
+        return CommandResult::err(e);
+    }
+
     if let Err(e) = state.storage_service.ensure_directories() {
         return CommandResult::err(format!("Failed to create storage directories: {e}"));
     }
 
-    let source = std::path::Path::new(&source_path);
+    let source = Path::new(&source_path);
     if !source.exists() {
         return CommandResult::err("Source screenshot file not found");
     }
 
     let img = match image::open(source) {
         Ok(i) => i,
-        Err(e) => return CommandResult::err(format!("Failed to open source image: {e}")),
+        Err(e) => {
+            let _ = std::fs::remove_file(&source_path);
+            return CommandResult::err(format!("Failed to open source image: {e}"));
+        }
     };
 
     let x = (region.x.max(0) as u32).min(img.width().saturating_sub(1));
@@ -222,7 +271,10 @@ pub fn finalize_region_capture(
     let original_path = state.storage_service.resolve_original_path(&filename);
     let original_str = match original_path.to_str() {
         Some(s) => s.to_string(),
-        None => return CommandResult::err("Invalid original path encoding"),
+        None => {
+            let _ = std::fs::remove_file(&source_path);
+            return CommandResult::err("Invalid original path encoding");
+        }
     };
 
     if let Err(e) = cropped.save_with_format(&original_path, image::ImageFormat::Png) {
@@ -288,6 +340,10 @@ pub fn finalize_region_capture(
 #[tauri::command]
 pub fn cancel_region_capture(source_path: String) -> CommandResult<()> {
     tracing::info!("Cancelling region capture");
+    if let Err(e) = validate_temp_path(&source_path) {
+        tracing::warn!("Invalid source path in cancel_region_capture: {}", e);
+        return CommandResult::success();
+    }
     let _ = std::fs::remove_file(&source_path);
     CommandResult::success()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,9 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::capture::capture,
+            commands::capture::prepare_region_capture,
+            commands::capture::finalize_region_capture,
+            commands::capture::cancel_region_capture,
             commands::workspace::get_workspace_items,
             commands::workspace::delete_workspace_item,
             commands::workspace::rename_workspace_item,

--- a/src-tauri/src/models/capture.rs
+++ b/src-tauri/src/models/capture.rs
@@ -25,3 +25,11 @@ pub struct CaptureResult {
     pub width: u32,
     pub height: u32,
 }
+
+/// Info returned after preparing a region capture
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegionCaptureInfo {
+    pub temp_path: String,
+    pub screen_width: u32,
+    pub screen_height: u32,
+}

--- a/src-tauri/src/models/capture.rs
+++ b/src-tauri/src/models/capture.rs
@@ -32,4 +32,5 @@ pub struct RegionCaptureInfo {
     pub temp_path: String,
     pub screen_width: u32,
     pub screen_height: u32,
+    pub image_data_uri: String,
 }

--- a/src/components/RegionCaptureOverlay.tsx
+++ b/src/components/RegionCaptureOverlay.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { convertFileSrc } from '@tauri-apps/api/core';
 import type { CaptureRegion, RegionCaptureInfo } from '@/types';
 
 interface RegionCaptureOverlayProps {

--- a/src/components/RegionCaptureOverlay.tsx
+++ b/src/components/RegionCaptureOverlay.tsx
@@ -33,6 +33,8 @@ export function RegionCaptureOverlay({
   const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
   const [imageBounds, setImageBounds] = useState<ImageBounds | null>(null);
 
+  const { imageDataUri } = captureInfo;
+
   const computeImageBounds = useCallback(() => {
     if (!containerRef.current) return;
     const container = containerRef.current;
@@ -72,22 +74,6 @@ export function RegionCaptureOverlay({
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [computeImageBounds]);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onCancel(captureInfo.tempPath);
-      }
-      if (e.key === 'Enter' && selection) {
-        const region = mapSelectionToScreen(selection);
-        if (region.width > 0 && region.height > 0) {
-          onConfirm(captureInfo.tempPath, region);
-        }
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  });
 
   const mapClientToScreen = useCallback(
     (clientX: number, clientY: number): { x: number; y: number } => {
@@ -129,6 +115,22 @@ export function RegionCaptureOverlay({
   }, [startPoint, currentPoint]);
 
   const selection = getSelection();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel(captureInfo.tempPath);
+      }
+      if (e.key === 'Enter' && selection) {
+        const region = mapSelectionToScreen(selection);
+        if (region.width > 0 && region.height > 0) {
+          onConfirm(captureInfo.tempPath, region);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel, onConfirm, captureInfo.tempPath, selection, mapSelectionToScreen]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     if (e.button !== 0) return;
@@ -180,7 +182,7 @@ export function RegionCaptureOverlay({
       onMouseLeave={() => setMousePos(null)}
     >
       <img
-        src={captureInfo.tempPath}
+        src={imageDataUri}
         className="absolute w-full h-full object-contain pointer-events-none"
         draggable={false}
         alt=""
@@ -202,7 +204,7 @@ export function RegionCaptureOverlay({
         >
           <div className="absolute inset-0 overflow-hidden">
             <img
-              src={captureInfo.tempPath}
+              src={imageDataUri}
               className="absolute w-full h-full object-contain pointer-events-none"
               draggable={false}
               alt=""

--- a/src/components/RegionCaptureOverlay.tsx
+++ b/src/components/RegionCaptureOverlay.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CaptureRegion, RegionCaptureInfo } from '@/types';
+
+interface RegionCaptureOverlayProps {
+  captureInfo: RegionCaptureInfo;
+  onConfirm: (sourcePath: string, region: CaptureRegion) => void;
+  onCancel: (sourcePath: string) => void;
+}
+
+interface SelectionRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface ImageBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function RegionCaptureOverlay({
+  captureInfo,
+  onConfirm,
+  onCancel,
+}: RegionCaptureOverlayProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isSelecting, setIsSelecting] = useState(false);
+  const [startPoint, setStartPoint] = useState<{ x: number; y: number } | null>(null);
+  const [currentPoint, setCurrentPoint] = useState<{ x: number; y: number } | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+  const [imageBounds, setImageBounds] = useState<ImageBounds | null>(null);
+
+  const computeImageBounds = useCallback(() => {
+    if (!containerRef.current) return;
+    const container = containerRef.current;
+    const containerWidth = container.clientWidth;
+    const containerHeight = container.clientHeight;
+    const imgAspect = captureInfo.screenWidth / captureInfo.screenHeight;
+    const containerAspect = containerWidth / containerHeight;
+
+    let renderedWidth: number;
+    let renderedHeight: number;
+    let offsetX: number;
+    let offsetY: number;
+
+    if (imgAspect > containerAspect) {
+      renderedWidth = containerWidth;
+      renderedHeight = containerWidth / imgAspect;
+      offsetX = 0;
+      offsetY = (containerHeight - renderedHeight) / 2;
+    } else {
+      renderedHeight = containerHeight;
+      renderedWidth = containerHeight * imgAspect;
+      offsetX = (containerWidth - renderedWidth) / 2;
+      offsetY = 0;
+    }
+
+    setImageBounds({
+      x: offsetX,
+      y: offsetY,
+      width: renderedWidth,
+      height: renderedHeight,
+    });
+  }, [captureInfo.screenWidth, captureInfo.screenHeight]);
+
+  useEffect(() => {
+    computeImageBounds();
+    const handleResize = () => computeImageBounds();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [computeImageBounds]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel(captureInfo.tempPath);
+      }
+      if (e.key === 'Enter' && selection) {
+        const region = mapSelectionToScreen(selection);
+        if (region.width > 0 && region.height > 0) {
+          onConfirm(captureInfo.tempPath, region);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  });
+
+  const mapClientToScreen = useCallback(
+    (clientX: number, clientY: number): { x: number; y: number } => {
+      if (!imageBounds) return { x: 0, y: 0 };
+      const relX = clientX - imageBounds.x;
+      const relY = clientY - imageBounds.y;
+      const scaleX = captureInfo.screenWidth / imageBounds.width;
+      const scaleY = captureInfo.screenHeight / imageBounds.height;
+      return {
+        x: Math.max(0, Math.min(Math.round(relX * scaleX), captureInfo.screenWidth)),
+        y: Math.max(0, Math.min(Math.round(relY * scaleY), captureInfo.screenHeight)),
+      };
+    },
+    [imageBounds, captureInfo.screenWidth, captureInfo.screenHeight],
+  );
+
+  const mapSelectionToScreen = useCallback(
+    (sel: SelectionRect): CaptureRegion => {
+      const topLeft = mapClientToScreen(sel.left, sel.top);
+      const bottomRight = mapClientToScreen(sel.left + sel.width, sel.top + sel.height);
+      return {
+        x: topLeft.x,
+        y: topLeft.y,
+        width: bottomRight.x - topLeft.x,
+        height: bottomRight.y - topLeft.y,
+      };
+    },
+    [mapClientToScreen],
+  );
+
+  const getSelection = useCallback((): SelectionRect | null => {
+    if (!startPoint || !currentPoint) return null;
+    const left = Math.min(startPoint.x, currentPoint.x);
+    const top = Math.min(startPoint.y, currentPoint.y);
+    const width = Math.abs(currentPoint.x - startPoint.x);
+    const height = Math.abs(currentPoint.y - startPoint.y);
+    if (width < 3 || height < 3) return null;
+    return { left, top, width, height };
+  }, [startPoint, currentPoint]);
+
+  const selection = getSelection();
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setStartPoint({ x, y });
+    setCurrentPoint({ x, y });
+    setIsSelecting(true);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setMousePos({ x, y });
+    if (isSelecting) {
+      setCurrentPoint({ x, y });
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (!isSelecting) return;
+    setIsSelecting(false);
+    if (selection) {
+      const region = mapSelectionToScreen(selection);
+      if (region.width > 0 && region.height > 0) {
+        onConfirm(captureInfo.tempPath, region);
+      }
+    }
+  };
+
+  const screenDim = selection
+    ? (() => {
+        const r = mapSelectionToScreen(selection);
+        return `${r.width} × ${r.height}`;
+      })()
+    : null;
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-0 z-50 cursor-crosshair bg-black select-none"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={() => setMousePos(null)}
+    >
+      <img
+        src={captureInfo.tempPath}
+        className="absolute w-full h-full object-contain pointer-events-none"
+        draggable={false}
+        alt=""
+      />
+
+      <div className="absolute inset-0 bg-black/40 pointer-events-none" />
+
+      {selection && (
+        <div
+          className="absolute border-2 border-white/90 pointer-events-none"
+          style={{
+            left: selection.left,
+            top: selection.top,
+            width: selection.width,
+            height: selection.height,
+            boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.4)',
+            zIndex: 10,
+          }}
+        >
+          <div className="absolute inset-0 overflow-hidden">
+            <img
+              src={captureInfo.tempPath}
+              className="absolute w-full h-full object-contain pointer-events-none"
+              draggable={false}
+              alt=""
+              style={{
+                left: imageBounds ? -selection.left + imageBounds.x : 0,
+                top: imageBounds ? -selection.top + imageBounds.y : 0,
+                width: imageBounds?.width,
+                height: imageBounds?.height,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {!selection && mousePos && (
+        <>
+          <div
+            className="absolute w-px h-full bg-white/40 pointer-events-none"
+            style={{ left: mousePos.x }}
+          />
+          <div
+            className="absolute h-px w-full bg-white/40 pointer-events-none"
+            style={{ top: mousePos.y }}
+          />
+        </>
+      )}
+
+      {screenDim && selection && (
+        <div
+          className="absolute text-white text-xs bg-black/70 px-2 py-1 rounded pointer-events-none whitespace-nowrap"
+          style={{
+            left: selection.left,
+            top: selection.top + selection.height + 4,
+            zIndex: 20,
+          }}
+        >
+          {screenDim}
+        </div>
+      )}
+
+      <div className="absolute bottom-6 left-1/2 -translate-x-1/2 text-white/70 text-sm pointer-events-none z-30">
+        ドラッグで範囲選択 · Enter で確定 · Esc でキャンセル
+      </div>
+    </div>
+  );
+}

--- a/src/components/RegionCaptureOverlay.tsx
+++ b/src/components/RegionCaptureOverlay.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import type { CaptureRegion, RegionCaptureInfo } from '@/types';
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import { Camera, Monitor, AppWindow } from 'lucide-react';
 
 interface ToolbarProps {
   onCaptureFullscreen: () => void;
-  onCaptureRegion: (region: { x: number; y: number; width: number; height: number }) => void;
+  onCaptureRegion: () => void;
   onCaptureWindow: () => void;
 }
 
@@ -11,7 +11,7 @@ export function Toolbar({ onCaptureFullscreen, onCaptureRegion, onCaptureWindow 
     <div className="flex items-center gap-1">
       <button
         className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
-        onClick={() => onCaptureRegion({ x: 0, y: 0, width: 0, height: 0 })}
+        onClick={onCaptureRegion}
         title="領域キャプチャ"
       >
         <Camera className="w-4 h-4" />

--- a/src/hooks/useCapture.ts
+++ b/src/hooks/useCapture.ts
@@ -1,5 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { CaptureRegion, CaptureType, CommandResult, WorkspaceItem } from '@/types';
+import type {
+  CaptureRegion,
+  CaptureType,
+  CommandResult,
+  RegionCaptureInfo,
+  WorkspaceItem,
+} from '@/types';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 export function useCapture() {
@@ -25,9 +31,49 @@ export function useCapture() {
   const captureRegion = (region: CaptureRegion) => capture('region', region);
   const captureWindow = () => capture('window');
 
+  const prepareRegionCapture = async (): Promise<CommandResult<RegionCaptureInfo>> => {
+    try {
+      const result = await invoke<CommandResult<RegionCaptureInfo>>('prepare_region_capture');
+      return result;
+    } catch (error) {
+      console.error('Prepare region capture failed:', error);
+      return { success: false, data: null, error: String(error) };
+    }
+  };
+
+  const finalizeRegionCapture = async (
+    sourcePath: string,
+    region: CaptureRegion,
+  ): Promise<CommandResult<WorkspaceItem>> => {
+    try {
+      const result = await invoke<CommandResult<WorkspaceItem>>('finalize_region_capture', {
+        sourcePath,
+        region,
+      });
+      if (result.success && result.data) {
+        addItem(result.data);
+      }
+      return result;
+    } catch (error) {
+      console.error('Finalize region capture failed:', error);
+      return { success: false, data: null, error: String(error) };
+    }
+  };
+
+  const cancelRegionCapture = async (sourcePath: string): Promise<void> => {
+    try {
+      await invoke<CommandResult<null>>('cancel_region_capture', { sourcePath });
+    } catch (error) {
+      console.error('Cancel region capture failed:', error);
+    }
+  };
+
   return {
     captureFullscreen,
     captureRegion,
     captureWindow,
+    prepareRegionCapture,
+    finalizeRegionCapture,
+    cancelRegionCapture,
   };
 }

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -8,8 +8,10 @@ import { ThumbnailGrid } from '@/components/ThumbnailGrid';
 import { DetailPanel } from '@/components/DetailPanel';
 import { Toolbar } from '@/components/Toolbar';
 import { TagFilterBar } from '@/components/TagFilterBar';
+import { RegionCaptureOverlay } from '@/components/RegionCaptureOverlay';
 import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
+import type { CaptureRegion, RegionCaptureInfo } from '@/types';
 
 export default function WorkspacePage() {
   const items = useWorkspaceStore((s) => s.items);
@@ -26,8 +28,10 @@ export default function WorkspacePage() {
 
   const { loadItems, deleteItem, toggleFavorite, renameItem, showInFolder, copyImageToClipboard } =
     useWorkspace();
-  const { captureFullscreen } = useCapture();
+  const { captureFullscreen, prepareRegionCapture, finalizeRegionCapture, cancelRegionCapture } =
+    useCapture();
   const [showDetail, setShowDetail] = useState(false);
+  const [regionCaptureInfo, setRegionCaptureInfo] = useState<RegionCaptureInfo | null>(null);
 
   useEffect(() => {
     loadItems();
@@ -88,18 +92,36 @@ export default function WorkspacePage() {
     await captureFullscreen();
   };
 
-  const handleCaptureRegion = (_region: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }) => {
-    // TODO: implement region capture
+  const handleCaptureRegion = async () => {
+    const result = await prepareRegionCapture();
+    if (result.success && result.data) {
+      setRegionCaptureInfo(result.data);
+    }
+  };
+
+  const handleRegionConfirm = async (sourcePath: string, region: CaptureRegion) => {
+    setRegionCaptureInfo(null);
+    await finalizeRegionCapture(sourcePath, region);
+  };
+
+  const handleRegionCancel = async (sourcePath: string) => {
+    setRegionCaptureInfo(null);
+    await cancelRegionCapture(sourcePath);
   };
 
   const handleCaptureWindow = () => {
     // TODO: implement window capture
   };
+
+  if (regionCaptureInfo) {
+    return (
+      <RegionCaptureOverlay
+        captureInfo={regionCaptureInfo}
+        onConfirm={handleRegionConfirm}
+        onCancel={handleRegionCancel}
+      />
+    );
+  }
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,7 @@ export interface RegionCaptureInfo {
   tempPath: string;
   screenWidth: number;
   screenHeight: number;
+  imageDataUri: string;
 }
 
 // === Editor Types ===

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,12 @@ export interface CaptureRegion {
 
 export type CaptureType = 'fullscreen' | 'region' | 'window';
 
+export interface RegionCaptureInfo {
+  tempPath: string;
+  screenWidth: number;
+  screenHeight: number;
+}
+
 // === Editor Types ===
 
 export type EditorTool = 'select' | 'arrow' | 'text' | 'rectangle' | 'mosaic' | 'crop';


### PR DESCRIPTION
## Summary

Closes #90

指定領域キャプチャ（Region Capture）機能を実装しました。

### 実装内容

- **半透明オーバーレイ表示**: フルスクリーンの黒背景オーバーレイ上にスクリーンショットを表示
- **ドラッグで範囲選択**: マウスドラッグで任意の矩形領域を選択、クロスヘアガイド表示
- **Enter確定またはマウスアップ確定**: 選択完了後、Enterキーまたはマウスボタン解放で確定
- **Escキャンセル**: Escキーでキャプチャを中断
- **保存と登録**: 選択範囲をクロップしてPNG保存、サムネイル生成、ワークスペースに登録

### アーキテクチャ

**バックエンド (Rust/Tauri)**:
- `prepare_region_capture`: ウィンドウを最小化→スクリーンショット取得→ウィンドウ復元
- `finalize_region_capture`: 一時画像から指定領域をクロップ→保存→DB登録
- `cancel_region_capture`: 一時ファイル削除

**フロントエンド (React/TypeScript)**:
- `RegionCaptureOverlay` コンポーネント: オーバーレイUI、ドラッグ選択、座標変換
- `useCapture` フック拡張: 3つの新Tauriコマンド呼び出し
- `WorkspacePage` にオーバーレイ統合

### テスト

- `cargo test`: 61 tests passed ✅
- `cargo clippy`: 新規コードに警告なし ✅