### PR TITLE
feat(capture): ウィンドウキャプチャを実装する

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ windows = { version = "0.59", features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Direct3D11",
     "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Dwm",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Threading",
 ] }

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -6,7 +6,7 @@ use tauri::State;
 
 use crate::app_state::AppState;
 use crate::error::CommandResult;
-use crate::models::capture::{CaptureRegion, RegionCaptureInfo};
+use crate::models::capture::{CaptureRegion, RegionCaptureInfo, WindowCaptureInfo};
 use crate::models::workspace_item::{WorkspaceItem, WorkspaceItemType};
 
 fn validate_temp_path(source_path: &str) -> Result<(), String> {
@@ -41,6 +41,7 @@ fn validate_temp_path(source_path: &str) -> Result<(), String> {
 pub fn capture(
     r#type: String,
     region: Option<CaptureRegion>,
+    hwnd: Option<isize>,
     state: State<'_, AppState>,
 ) -> CommandResult<WorkspaceItem> {
     match r#type.as_str() {
@@ -139,8 +140,91 @@ pub fn capture(
             }
         }
         "window" => {
-            tracing::info!("Window capture requested");
-            CommandResult::err("Window capture not yet implemented")
+            let hwnd_val = match hwnd {
+                Some(h) => h,
+                None => return CommandResult::err("Window handle (hwnd) not specified"),
+            };
+            tracing::info!("Window capture requested for hwnd={}", hwnd_val);
+
+            if let Err(e) = state.storage_service.ensure_directories() {
+                return CommandResult::err(format!("Failed to create storage directories: {e}"));
+            }
+
+            let filename = format!(
+                "capture_{}.png",
+                chrono::Local::now().format("%Y%m%d_%H%M%S")
+            );
+
+            let original_path = state.storage_service.resolve_original_path(&filename);
+            let original_str = match original_path.to_str() {
+                Some(s) => s.to_string(),
+                None => return CommandResult::err("Invalid original path encoding"),
+            };
+
+            let capture_result = match state
+                .capture_service
+                .capture_window(hwnd_val, &original_str)
+            {
+                Ok(r) => r,
+                Err(e) => return CommandResult::err(e.to_string()),
+            };
+
+            let edited_path = state.storage_service.resolve_edited_path(&filename);
+            let edited_str = match edited_path.to_str() {
+                Some(s) => s.to_string(),
+                None => return CommandResult::err("Invalid edited path encoding"),
+            };
+
+            if let Err(e) = std::fs::copy(&original_path, &edited_path) {
+                return CommandResult::err(format!(
+                    "Failed to copy original to edited directory: {e}"
+                ));
+            }
+
+            let thumb_path = state.storage_service.resolve_thumbnail_path(&filename);
+            let thumb_str = match thumb_path.to_str() {
+                Some(s) => s.to_string(),
+                None => return CommandResult::err("Invalid thumbnail path encoding"),
+            };
+
+            if let Err(e) = state
+                .thumbnail_service
+                .generate_thumbnail(&original_str, &thumb_str)
+            {
+                return CommandResult::err(format!("Failed to generate thumbnail: {e}"));
+            }
+
+            let now = chrono::Utc::now().to_rfc3339();
+            let title = format!(
+                "Window Capture {}",
+                chrono::Local::now().format("%Y/%m/%d %H:%M:%S")
+            );
+
+            let item = WorkspaceItem {
+                id: uuid::Uuid::new_v4().to_string(),
+                item_type: WorkspaceItemType::Image,
+                original_path: original_str,
+                current_path: edited_str,
+                thumbnail_path: Some(thumb_str),
+                title,
+                created_at: now.clone(),
+                updated_at: now,
+                is_favorite: false,
+                metadata_json: None,
+            };
+
+            match state.workspace_service.add_item(&item) {
+                Ok(()) => {
+                    tracing::info!(
+                        "Window capture saved: {} ({}x{})",
+                        item.id,
+                        capture_result.width,
+                        capture_result.height
+                    );
+                    CommandResult::ok(item)
+                }
+                Err(e) => CommandResult::err(e.to_string()),
+            }
         }
         _ => CommandResult::err(format!("Unknown capture type: {}", r#type)),
     }
@@ -356,4 +440,42 @@ pub fn cancel_region_capture(source_path: String) -> CommandResult<()> {
     }
     let _ = std::fs::remove_file(&source_path);
     CommandResult::success()
+}
+
+#[tauri::command]
+pub fn prepare_window_capture(app: tauri::AppHandle) -> CommandResult<WindowCaptureInfo> {
+    use crate::platform;
+
+    tracing::info!("Preparing window capture");
+
+    let window = match app.get_webview_window("main") {
+        Some(w) => w,
+        None => return CommandResult::err("Main window not found"),
+    };
+
+    if let Err(e) = window.minimize() {
+        tracing::warn!("Failed to minimize window: {}", e);
+    }
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let windows = match platform::enumerate_windows() {
+        Ok(w) => w,
+        Err(e) => {
+            let _ = window.unminimize();
+            let _ = window.set_focus();
+            return CommandResult::err(format!("Failed to enumerate windows: {e}"));
+        }
+    };
+
+    if let Err(e) = window.unminimize() {
+        tracing::warn!("Failed to unminimize window: {}", e);
+    }
+    if let Err(e) = window.set_focus() {
+        tracing::warn!("Failed to focus window: {}", e);
+    }
+
+    tracing::info!("Found {} windows for capture", windows.len());
+
+    CommandResult::ok(WindowCaptureInfo { windows })
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
             commands::capture::prepare_region_capture,
             commands::capture::finalize_region_capture,
             commands::capture::cancel_region_capture,
+            commands::capture::prepare_window_capture,
             commands::workspace::get_workspace_items,
             commands::workspace::delete_workspace_item,
             commands::workspace::rename_workspace_item,

--- a/src-tauri/src/models/capture.rs
+++ b/src-tauri/src/models/capture.rs
@@ -34,3 +34,9 @@ pub struct RegionCaptureInfo {
     pub screen_height: u32,
     pub image_data_uri: String,
 }
+
+/// Info returned when preparing a window capture (list of available windows)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowCaptureInfo {
+    pub windows: Vec<WindowInfo>,
+}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,23 +1,123 @@
-/// Platform-specific operations module.
-///
-/// This module provides abstractions for OS-specific functionality
-/// such as screen capture via Windows API, window enumeration,
-/// and global hotkey registration.
-///
-/// Actual implementations will use the `windows` crate for Win32 API calls.
 use crate::error::AppResult;
+use crate::models::capture::WindowInfo;
 
-/// Get the list of monitors (placeholder)
 pub fn enumerate_monitors() -> AppResult<Vec<MonitorInfo>> {
     tracing::debug!("Enumerating monitors (not yet implemented)");
     Ok(vec![])
 }
 
-/// Monitor information
 #[derive(Debug, Clone)]
 pub struct MonitorInfo {
     pub id: u32,
     pub name: String,
     pub bounds: (i32, i32, i32, i32),
     pub is_primary: bool,
+}
+
+#[cfg(target_os = "windows")]
+pub fn enumerate_windows() -> AppResult<Vec<WindowInfo>> {
+    use windows::Win32::UI::WindowsAndMessaging::EnumWindows;
+
+    let windows: Vec<WindowInfo> = Vec::new();
+    let boxed = Box::new(windows);
+    let ptr = Box::into_raw(boxed);
+
+    let result = unsafe {
+        EnumWindows(
+            Some(enum_windows_callback),
+            windows::Win32::Foundation::LPARAM(ptr as isize),
+        )
+    };
+
+    let mut found = if result.is_ok() {
+        let boxed = unsafe { Box::from_raw(ptr) };
+        *boxed
+    } else {
+        let _ = unsafe { Box::from_raw(ptr) };
+        Vec::new()
+    };
+
+    found.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+    Ok(found)
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn enum_windows_callback(
+    hwnd: windows::Win32::Foundation::HWND,
+    lparam: windows::Win32::Foundation::LPARAM,
+) -> windows::Win32::Foundation::BOOL {
+    use windows::Win32::Foundation::TRUE;
+    use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetClassNameW, GetWindowLongPtrW, GetWindowRect, GetWindowTextW, IsIconic, IsWindowVisible,
+        GWL_STYLE, WS_DISABLED,
+    };
+
+    let windows = &mut *(lparam.0 as *mut Vec<WindowInfo>);
+
+    if !IsWindowVisible(hwnd).as_bool() {
+        return TRUE;
+    }
+
+    let style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    if (style & WS_DISABLED.0 as isize) != 0 {
+        return TRUE;
+    }
+
+    if IsIconic(hwnd).as_bool() {
+        return TRUE;
+    }
+
+    let mut title_buf = [0u16; 512];
+    let title_len = GetWindowTextW(hwnd, &mut title_buf);
+    if title_len == 0 {
+        return TRUE;
+    }
+    let title = String::from_utf16_lossy(&title_buf[..title_len as usize]);
+    if title.trim().is_empty() {
+        return TRUE;
+    }
+
+    let mut class_buf = [0u16; 256];
+    let class_len = GetClassNameW(hwnd, &mut class_buf);
+    let class_name = String::from_utf16_lossy(&class_buf[..class_len as usize]);
+
+    let mut rect: windows::Win32::Foundation::RECT = std::mem::zeroed();
+    let hr = DwmGetWindowAttribute(
+        hwnd,
+        DWMWA_EXTENDED_FRAME_BOUNDS,
+        &mut rect as *mut _ as *mut _,
+        std::mem::size_of::<windows::Win32::Foundation::RECT>() as u32,
+    );
+    let bounds = if hr.is_ok() {
+        (
+            rect.left,
+            rect.top,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+        )
+    } else {
+        let mut rect2 = std::mem::zeroed();
+        let _ = GetWindowRect(hwnd, &mut rect2);
+        (
+            rect2.left,
+            rect2.top,
+            rect2.right - rect2.left,
+            rect2.bottom - rect2.top,
+        )
+    };
+
+    windows.push(WindowInfo {
+        hwnd: hwnd.0 as isize,
+        title,
+        class_name,
+        bounds,
+    });
+
+    TRUE
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn enumerate_windows() -> AppResult<Vec<WindowInfo>> {
+    Ok(vec![])
 }

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -34,11 +34,9 @@ impl CaptureService for DefaultCaptureService {
         ))
     }
 
-    fn capture_window(&self, hwnd: isize, _save_path: &str) -> AppResult<CaptureResult> {
+    fn capture_window(&self, hwnd: isize, save_path: &str) -> AppResult<CaptureResult> {
         tracing::info!("Window capture requested for hwnd={}", hwnd);
-        Err(AppError::Capture(
-            "Window capture not yet implemented".into(),
-        ))
+        capture_window_by_hwnd(hwnd, save_path)
     }
 }
 
@@ -217,6 +215,113 @@ fn capture_screen(save_path: &str) -> AppResult<CaptureResult> {
             .map_err(|e| AppError::Capture(format!("Failed to save captured image: {e}")))?;
 
         screen_dc.release();
+
+        Ok(CaptureResult {
+            file_path: save_path.to_string(),
+            width: width as u32,
+            height: height as u32,
+        })
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn capture_window_by_hwnd(hwnd: isize, save_path: &str) -> AppResult<CaptureResult> {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
+    use windows::Win32::Graphics::Gdi::*;
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    let save = std::path::Path::new(save_path);
+    if let Some(parent) = save.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let hwnd = HWND(hwnd as *mut _);
+
+    let (width, height) = unsafe {
+        let mut rect: windows::Win32::Foundation::RECT = std::mem::zeroed();
+        let hr = DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            &mut rect as *mut _ as *mut _,
+            std::mem::size_of::<windows::Win32::Foundation::RECT>() as u32,
+        );
+        if hr.is_ok() && rect.right > rect.left && rect.bottom > rect.top {
+            (rect.right - rect.left, rect.bottom - rect.top)
+        } else {
+            let mut fallback: windows::Win32::Foundation::RECT = std::mem::zeroed();
+            let _ = GetWindowRect(hwnd, &mut fallback);
+            (
+                fallback.right - fallback.left,
+                fallback.bottom - fallback.top,
+            )
+        }
+    };
+
+    if width <= 0 || height <= 0 {
+        return Err(AppError::Capture("Invalid window dimensions".into()));
+    }
+
+    unsafe {
+        let window_dc = GetWindowDC(Some(hwnd));
+        let mem_dc = CreateCompatibleDC(Some(window_dc));
+        let bitmap = CreateCompatibleBitmap(window_dc, width, height);
+        let old = SelectObject(mem_dc, bitmap.into());
+
+        let _gdi = gdi_guard::GdiCleanup::new(mem_dc, bitmap, old);
+
+        if let Err(e) = BitBlt(
+            mem_dc,
+            0,
+            0,
+            width,
+            height,
+            Some(window_dc),
+            0,
+            0,
+            SRCCOPY | CAPTUREBLT,
+        ) {
+            let _ = ReleaseDC(Some(hwnd), window_dc);
+            return Err(AppError::Capture(format!("BitBlt failed: {e}")));
+        }
+
+        let mut bmi: BITMAPINFO = std::mem::zeroed();
+        bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
+        bmi.bmiHeader.biWidth = width;
+        bmi.bmiHeader.biHeight = -height;
+        bmi.bmiHeader.biPlanes = 1;
+        bmi.bmiHeader.biBitCount = 32;
+
+        let buf_size = (width as usize) * (height as usize) * 4;
+        let mut pixels = vec![0u8; buf_size];
+
+        let scan_lines = GetDIBits(
+            mem_dc,
+            bitmap,
+            0,
+            height as u32,
+            Some(pixels.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+
+        let _ = ReleaseDC(Some(hwnd), window_dc);
+
+        if scan_lines == 0 {
+            return Err(AppError::Capture("GetDIBits returned 0 scan lines".into()));
+        }
+
+        for chunk in pixels.chunks_exact_mut(4) {
+            chunk.swap(0, 2);
+        }
+
+        let img =
+            image::RgbaImage::from_raw(width as u32, height as u32, pixels).ok_or_else(|| {
+                AppError::Capture("Failed to create image from captured pixels".into())
+            })?;
+
+        img.save_with_format(save, image::ImageFormat::Png)
+            .map_err(|e| AppError::Capture(format!("Failed to save captured image: {e}")))?;
 
         Ok(CaptureResult {
             file_path: save_path.to_string(),

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -67,6 +67,7 @@ impl CaptureService for DefaultCaptureService {
 
 #[cfg(target_os = "windows")]
 mod gdi_guard {
+    use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Gdi::{
         DeleteDC, DeleteObject, ReleaseDC, SelectObject, HBITMAP, HDC, HGDIOBJ,
     };
@@ -102,6 +103,37 @@ mod gdi_guard {
                 unsafe {
                     let _ = ReleaseDC(None, self.dc);
                 }
+            }
+        }
+    }
+
+    pub struct WindowDcGuard {
+        hwnd: HWND,
+        dc: HDC,
+        released: bool,
+    }
+
+    impl WindowDcGuard {
+        pub fn new(hwnd: HWND, dc: HDC) -> Self {
+            Self {
+                hwnd,
+                dc,
+                released: false,
+            }
+        }
+
+        pub fn get(&self) -> HDC {
+            self.dc
+        }
+    }
+
+    impl Drop for WindowDcGuard {
+        fn drop(&mut self) {
+            if !self.released {
+                unsafe {
+                    let _ = ReleaseDC(Some(self.hwnd), self.dc);
+                }
+                self.released = true;
             }
         }
     }
@@ -263,7 +295,8 @@ fn capture_window_by_hwnd(hwnd: isize, save_path: &str) -> AppResult<CaptureResu
     }
 
     unsafe {
-        let window_dc = GetWindowDC(Some(hwnd));
+        let window_dc_guard = gdi_guard::WindowDcGuard::new(hwnd, GetWindowDC(Some(hwnd)));
+        let window_dc = window_dc_guard.get();
         let mem_dc = CreateCompatibleDC(Some(window_dc));
         let bitmap = CreateCompatibleBitmap(window_dc, width, height);
         let old = SelectObject(mem_dc, bitmap.into());
@@ -281,7 +314,6 @@ fn capture_window_by_hwnd(hwnd: isize, save_path: &str) -> AppResult<CaptureResu
             0,
             SRCCOPY | CAPTUREBLT,
         ) {
-            let _ = ReleaseDC(Some(hwnd), window_dc);
             return Err(AppError::Capture(format!("BitBlt failed: {e}")));
         }
 
@@ -305,7 +337,7 @@ fn capture_window_by_hwnd(hwnd: isize, save_path: &str) -> AppResult<CaptureResu
             DIB_RGB_COLORS,
         );
 
-        let _ = ReleaseDC(Some(hwnd), window_dc);
+        drop(window_dc_guard);
 
         if scan_lines == 0 {
             return Err(AppError::Capture("GetDIBits returned 0 scan lines".into()));

--- a/src/components/WindowCaptureOverlay.tsx
+++ b/src/components/WindowCaptureOverlay.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { AppWindow, X } from 'lucide-react';
+import type { WindowInfo } from '@/types';
+
+interface WindowCaptureOverlayProps {
+  windows: WindowInfo[];
+  onSelect: (hwnd: number) => void;
+  onCancel: () => void;
+}
+
+export function WindowCaptureOverlay({ windows, onSelect, onCancel }: WindowCaptureOverlayProps) {
+  const [selectedHwnd, setSelectedHwnd] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredWindows = windows.filter(
+    (w) =>
+      w.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      w.className.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  const handleConfirm = () => {
+    if (selectedHwnd !== null) {
+      onSelect(selectedHwnd);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onCancel();
+    } else if (e.key === 'Enter' && selectedHwnd !== null) {
+      handleConfirm();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="relative flex w-full max-w-2xl flex-col rounded-lg border border-border bg-background shadow-2xl">
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <AppWindow className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-semibold">ウィンドウを選択</h2>
+          </div>
+          <button
+            className="rounded-md p-1 hover:bg-accent"
+            onClick={onCancel}
+            title="キャンセル (Esc)"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="border-b border-border px-4 py-2">
+          <input
+            type="text"
+            className="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring"
+            placeholder="ウィンドウを検索..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-96 overflow-y-auto p-2">
+          {filteredWindows.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+              <p className="text-sm">該当するウィンドウが見つかりません</p>
+            </div>
+          ) : (
+            filteredWindows.map((w) => (
+              <button
+                key={w.hwnd}
+                className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                  selectedHwnd === w.hwnd ? 'bg-primary text-primary-foreground' : 'hover:bg-accent'
+                }`}
+                onClick={() => setSelectedHwnd(w.hwnd)}
+                onDoubleClick={() => onSelect(w.hwnd)}
+              >
+                <AppWindow className="h-4 w-4 shrink-0" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium">{w.title}</p>
+                  <p
+                    className={`truncate text-xs ${
+                      selectedHwnd === w.hwnd
+                        ? 'text-primary-foreground/70'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {w.className} &middot; {w.bounds[2]}x{w.bounds[3]}
+                  </p>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+          <button className="rounded-md px-4 py-1.5 text-sm hover:bg-accent" onClick={onCancel}>
+            キャンセル
+          </button>
+          <button
+            className="rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            onClick={handleConfirm}
+            disabled={selectedHwnd === null}
+          >
+            キャプチャ
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useCapture.ts
+++ b/src/hooks/useCapture.ts
@@ -4,6 +4,7 @@ import type {
   CaptureType,
   CommandResult,
   RegionCaptureInfo,
+  WindowCaptureInfo,
   WorkspaceItem,
 } from '@/types';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -11,11 +12,12 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 export function useCapture() {
   const addItem = useWorkspaceStore((s) => s.addItem);
 
-  const capture = async (type: CaptureType, region?: CaptureRegion) => {
+  const capture = async (type: CaptureType, region?: CaptureRegion, hwnd?: number) => {
     try {
       const result = await invoke<CommandResult<WorkspaceItem>>('capture', {
         type,
         region: region ?? null,
+        hwnd: hwnd ?? null,
       });
       if (result.success && result.data) {
         addItem(result.data);
@@ -29,7 +31,7 @@ export function useCapture() {
 
   const captureFullscreen = () => capture('fullscreen');
   const captureRegion = (region: CaptureRegion) => capture('region', region);
-  const captureWindow = () => capture('window');
+  const captureWindow = (hwnd: number) => capture('window', undefined, hwnd);
 
   const prepareRegionCapture = async (): Promise<CommandResult<RegionCaptureInfo>> => {
     try {
@@ -68,6 +70,16 @@ export function useCapture() {
     }
   };
 
+  const prepareWindowCapture = async (): Promise<CommandResult<WindowCaptureInfo>> => {
+    try {
+      const result = await invoke<CommandResult<WindowCaptureInfo>>('prepare_window_capture');
+      return result;
+    } catch (error) {
+      console.error('Prepare window capture failed:', error);
+      return { success: false, data: null, error: String(error) };
+    }
+  };
+
   return {
     captureFullscreen,
     captureRegion,
@@ -75,5 +87,6 @@ export function useCapture() {
     prepareRegionCapture,
     finalizeRegionCapture,
     cancelRegionCapture,
+    prepareWindowCapture,
   };
 }

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -9,9 +9,10 @@ import { DetailPanel } from '@/components/DetailPanel';
 import { Toolbar } from '@/components/Toolbar';
 import { TagFilterBar } from '@/components/TagFilterBar';
 import { RegionCaptureOverlay } from '@/components/RegionCaptureOverlay';
+import { WindowCaptureOverlay } from '@/components/WindowCaptureOverlay';
 import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
-import type { CaptureRegion, RegionCaptureInfo } from '@/types';
+import type { CaptureRegion, RegionCaptureInfo, WindowInfo } from '@/types';
 
 export default function WorkspacePage() {
   const items = useWorkspaceStore((s) => s.items);
@@ -28,10 +29,17 @@ export default function WorkspacePage() {
 
   const { loadItems, deleteItem, toggleFavorite, renameItem, showInFolder, copyImageToClipboard } =
     useWorkspace();
-  const { captureFullscreen, prepareRegionCapture, finalizeRegionCapture, cancelRegionCapture } =
-    useCapture();
+  const {
+    captureFullscreen,
+    captureWindow,
+    prepareRegionCapture,
+    finalizeRegionCapture,
+    cancelRegionCapture,
+    prepareWindowCapture,
+  } = useCapture();
   const [showDetail, setShowDetail] = useState(false);
   const [regionCaptureInfo, setRegionCaptureInfo] = useState<RegionCaptureInfo | null>(null);
+  const [windowCaptureList, setWindowCaptureList] = useState<WindowInfo[] | null>(null);
 
   useEffect(() => {
     loadItems();
@@ -109,8 +117,20 @@ export default function WorkspacePage() {
     await cancelRegionCapture(sourcePath);
   };
 
-  const handleCaptureWindow = () => {
-    // TODO: implement window capture
+  const handleCaptureWindow = async () => {
+    const result = await prepareWindowCapture();
+    if (result.success && result.data) {
+      setWindowCaptureList(result.data.windows);
+    }
+  };
+
+  const handleWindowSelect = async (hwnd: number) => {
+    setWindowCaptureList(null);
+    await captureWindow(hwnd);
+  };
+
+  const handleWindowCancel = () => {
+    setWindowCaptureList(null);
   };
 
   if (regionCaptureInfo) {
@@ -119,6 +139,16 @@ export default function WorkspacePage() {
         captureInfo={regionCaptureInfo}
         onConfirm={handleRegionConfirm}
         onCancel={handleRegionCancel}
+      />
+    );
+  }
+
+  if (windowCaptureList) {
+    return (
+      <WindowCaptureOverlay
+        windows={windowCaptureList}
+        onSelect={handleWindowSelect}
+        onCancel={handleWindowCancel}
       />
     );
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,17 @@ export interface RegionCaptureInfo {
   imageDataUri: string;
 }
 
+export interface WindowInfo {
+  hwnd: number;
+  title: string;
+  className: string;
+  bounds: [number, number, number, number];
+}
+
+export interface WindowCaptureInfo {
+  windows: WindowInfo[];
+}
+
 // === Editor Types ===
 
 export type EditorTool = 'select' | 'arrow' | 'text' | 'rectangle' | 'mosaic' | 'crop';


### PR DESCRIPTION
## Summary

Closes #91

ウィンドウ単位でキャプチャする機能を実装しました。

### 変更内容

**バックエンド (Rust/Tauri):**
- `platform::enumerate_windows()` を実装 — `EnumWindows` API で可視ウィンドウを列挙し、`DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)` で影を含まない正確なウィンドウ境界を取得
- `capture_window_by_hwnd()` を実装 — `GetWindowDC` + `BitBlt(SRCCOPY | CAPTUREBLT)` でウィンドウキャプチャを実行
- `prepare_window_capture` IPCコマンドを追加 — ウィンドウ列挙情報をフロントエンドに返す
- `capture` コマンドの `window` タイプを `hwnd` パラメータ対応に更新

**フロントエンド (React/TypeScript):**
- `WindowCaptureOverlay` コンポーネントを追加 — 検索可能なウィンドウ一覧からキャプチャ対象を選択するモーダルUI
- `useCapture` フックに `prepareWindowCapture` / `captureWindow` を追加
- `WindowInfo` / `WindowCaptureInfo` 型を追加
- `WorkspacePage` でウィンドウキャプチャフローを統合

### 完了条件の確認

- [x] ウィンドウ単位で画像保存できる
- [x] ワークスペースへ登録される
- [x] 影や境界の扱いが破綻しない（DWMWA_EXTENDED_FRAME_BOUNDS を使用）