### PR TITLE
feat(capture): implement global hotkey support (#92)

### DIFF
--- a/src-tauri/src/config/app_settings.rs
+++ b/src-tauri/src/config/app_settings.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Application settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSettings {
     pub save_path: String,
     pub image_format: String,

--- a/src/hooks/useGlobalShortcut.ts
+++ b/src/hooks/useGlobalShortcut.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { register, unregisterAll } from '@tauri-apps/plugin-global-shortcut';
+import { register, unregister } from '@tauri-apps/plugin-global-shortcut';
 import { invoke } from '@tauri-apps/api/core';
 import type { AppSettings, CommandResult } from '@/types';
 
@@ -11,11 +11,12 @@ export function useGlobalShortcut(onAction: (action: CaptureAction) => void) {
 
   useEffect(() => {
     let cancelled = false;
+    const registeredShortcuts: string[] = [];
 
     const setup = async () => {
       try {
         const result = await invoke<CommandResult<AppSettings>>('get_settings');
-        if (!result.success || !result.data) return;
+        if (cancelled || !result.success || !result.data) return;
 
         const { hotkeyCaptureRegion, hotkeyCaptureFullscreen, hotkeyCaptureWindow } = result.data;
 
@@ -24,7 +25,7 @@ export function useGlobalShortcut(onAction: (action: CaptureAction) => void) {
         if (hotkeyCaptureFullscreen) entries.push([hotkeyCaptureFullscreen, 'fullscreen']);
         if (hotkeyCaptureWindow) entries.push([hotkeyCaptureWindow, 'window']);
 
-        if (entries.length === 0) return;
+        if (entries.length === 0 || cancelled) return;
 
         const shortcuts = entries.map(([s]) => s);
         const shortcutMap = Object.fromEntries(entries);
@@ -37,20 +38,30 @@ export function useGlobalShortcut(onAction: (action: CaptureAction) => void) {
               onActionRef.current(action);
             }
           });
+          registeredShortcuts.push(...shortcuts);
         } catch {
+          if (cancelled) return;
           for (const [shortcut, action] of entries) {
+            if (cancelled) break;
             try {
               await register(shortcut, (event) => {
                 if (event.state !== 'Pressed' || cancelled) return;
                 onActionRef.current(action);
               });
+              registeredShortcuts.push(shortcut);
             } catch (e) {
               console.warn(`Failed to register hotkey "${shortcut}" for ${action}:`, e);
             }
           }
         }
+
+        if (cancelled && registeredShortcuts.length > 0) {
+          unregister(registeredShortcuts).catch(() => {});
+        }
       } catch (error) {
-        console.error('Failed to setup global shortcuts:', error);
+        if (!cancelled) {
+          console.error('Failed to setup global shortcuts:', error);
+        }
       }
     };
 
@@ -58,7 +69,9 @@ export function useGlobalShortcut(onAction: (action: CaptureAction) => void) {
 
     return () => {
       cancelled = true;
-      unregisterAll().catch(() => {});
+      if (registeredShortcuts.length > 0) {
+        unregister(registeredShortcuts).catch(() => {});
+      }
     };
   }, []);
 }

--- a/src/hooks/useGlobalShortcut.ts
+++ b/src/hooks/useGlobalShortcut.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import { register, unregisterAll } from '@tauri-apps/plugin-global-shortcut';
+import { invoke } from '@tauri-apps/api/core';
+import type { AppSettings, CommandResult } from '@/types';
+
+export type CaptureAction = 'region' | 'fullscreen' | 'window';
+
+export function useGlobalShortcut(onAction: (action: CaptureAction) => void) {
+  const onActionRef = useRef(onAction);
+  onActionRef.current = onAction;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const setup = async () => {
+      try {
+        const result = await invoke<CommandResult<AppSettings>>('get_settings');
+        if (!result.success || !result.data) return;
+
+        const { hotkeyCaptureRegion, hotkeyCaptureFullscreen, hotkeyCaptureWindow } = result.data;
+
+        const entries: [string, CaptureAction][] = [];
+        if (hotkeyCaptureRegion) entries.push([hotkeyCaptureRegion, 'region']);
+        if (hotkeyCaptureFullscreen) entries.push([hotkeyCaptureFullscreen, 'fullscreen']);
+        if (hotkeyCaptureWindow) entries.push([hotkeyCaptureWindow, 'window']);
+
+        if (entries.length === 0) return;
+
+        const shortcuts = entries.map(([s]) => s);
+        const shortcutMap = Object.fromEntries(entries);
+
+        try {
+          await register(shortcuts, (event) => {
+            if (event.state !== 'Pressed' || cancelled) return;
+            const action = shortcutMap[event.shortcut];
+            if (action) {
+              onActionRef.current(action);
+            }
+          });
+        } catch {
+          for (const [shortcut, action] of entries) {
+            try {
+              await register(shortcut, (event) => {
+                if (event.state !== 'Pressed' || cancelled) return;
+                onActionRef.current(action);
+              });
+            } catch (e) {
+              console.warn(`Failed to register hotkey "${shortcut}" for ${action}:`, e);
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Failed to setup global shortcuts:', error);
+      }
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      unregisterAll().catch(() => {});
+    };
+  }, []);
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -10,6 +10,8 @@ import { Toolbar } from '@/components/Toolbar';
 import { TagFilterBar } from '@/components/TagFilterBar';
 import { RegionCaptureOverlay } from '@/components/RegionCaptureOverlay';
 import { WindowCaptureOverlay } from '@/components/WindowCaptureOverlay';
+import { useGlobalShortcut } from '@/hooks/useGlobalShortcut';
+import type { CaptureAction } from '@/hooks/useGlobalShortcut';
 import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 import type { CaptureRegion, RegionCaptureInfo, WindowInfo } from '@/types';
@@ -44,6 +46,21 @@ export default function WorkspacePage() {
   useEffect(() => {
     loadItems();
   }, []);
+
+  useGlobalShortcut((action: CaptureAction) => {
+    if (regionCaptureInfo || windowCaptureList) return;
+    switch (action) {
+      case 'fullscreen':
+        handleCaptureFullscreen();
+        break;
+      case 'region':
+        handleCaptureRegion();
+        break;
+      case 'window':
+        handleCaptureWindow();
+        break;
+    }
+  });
 
   const filteredItems = useMemo(() => {
     let result = [...items];


### PR DESCRIPTION
## Summary

- Implement global hotkey support using `tauri-plugin-global-shortcut` to enable capture actions when the app is inactive
- Create `useGlobalShortcut` hook that loads hotkey settings from the backend and registers OS-level shortcuts on mount
- Map configurable hotkeys to region/fullscreen/window capture actions with proper error handling for duplicate registration
- Add `#[serde(rename_all = "camelCase")]` to `AppSettings` for consistency with TypeScript type definitions

Closes #92