### PR TITLE
feat(tray): implement system tray with minimize-to-tray and capture menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
-    Emitter, Manager, RunEvent,
+    Emitter, Manager,
 };
 
 use crate::app_state::AppState;
@@ -134,14 +134,19 @@ pub fn run() {
 
             let menu = Menu::with_items(app, &[&show, &capture_submenu, &separator, &quit])?;
 
-            let _tray = TrayIconBuilder::new()
-                .icon(app.default_window_icon().cloned().unwrap())
+            let tray = TrayIconBuilder::new()
+                .icon(
+                    app.default_window_icon()
+                        .cloned()
+                        .ok_or("Failed to get default window icon")?,
+                )
                 .menu(&menu)
                 .show_menu_on_left_click(false)
                 .tooltip("AmeCapture")
                 .on_menu_event(move |app, event| match event.id.as_ref() {
                     "show" => {
                         if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
                             let _ = window.unminimize();
                             let _ = window.set_focus();
                         }
@@ -161,13 +166,14 @@ pub fn run() {
                     _ => {}
                 })
                 .build(app)?;
+            Box::leak(Box::new(tray));
 
             tracing::info!("AmeCapture initialized successfully");
             Ok(())
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                window.hide().unwrap();
+                let _ = window.hide();
                 api.prevent_close();
             }
         })
@@ -200,11 +206,6 @@ pub fn run() {
             commands::tag::get_items_by_tag,
             commands::tag::get_all_tags_for_items,
         ])
-        .build(tauri::generate_context!())
-        .expect("error while building tauri application")
-        .run(|_app_handle, event| {
-            if let RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
-            }
-        });
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,11 @@ mod storage;
 
 use std::sync::{Arc, Mutex};
 
-use tauri::Manager;
+use tauri::{
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
+    tray::TrayIconBuilder,
+    Emitter, Manager, RunEvent,
+};
 
 use crate::app_state::AppState;
 use crate::db::connection::create_connection;
@@ -43,8 +47,6 @@ pub fn run() {
                 .expect("Failed to get app data dir")
                 .join("logs");
 
-            // The WorkerGuard must be kept alive for the lifetime of the app.
-            // We leak it intentionally so it's never dropped and logs are flushed.
             let guard = logging::init_logging(log_dir);
             if let Some(guard) = guard {
                 Box::leak(Box::new(guard));
@@ -97,8 +99,77 @@ pub fn run() {
 
             app.manage(app_state);
 
+            // === System Tray ===
+            let show = MenuItem::with_id(app, "show", "ウィンドウを表示", true, None::<&str>)?;
+            let capture_submenu = Submenu::with_items(
+                app,
+                "キャプチャ",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        app,
+                        "capture_region",
+                        "範囲キャプチャ",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        app,
+                        "capture_fullscreen",
+                        "全画面キャプチャ",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        app,
+                        "capture_window",
+                        "ウィンドウキャプチャ",
+                        true,
+                        None::<&str>,
+                    )?,
+                ],
+            )?;
+            let separator = PredefinedMenuItem::separator(app)?;
+            let quit = MenuItem::with_id(app, "quit", "終了", true, None::<&str>)?;
+
+            let menu = Menu::with_items(app, &[&show, &capture_submenu, &separator, &quit])?;
+
+            let _tray = TrayIconBuilder::new()
+                .icon(app.default_window_icon().cloned().unwrap())
+                .menu(&menu)
+                .show_menu_on_left_click(false)
+                .tooltip("AmeCapture")
+                .on_menu_event(move |app, event| match event.id.as_ref() {
+                    "show" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.unminimize();
+                            let _ = window.set_focus();
+                        }
+                    }
+                    "capture_region" => {
+                        let _ = app.emit("tray-capture", "region");
+                    }
+                    "capture_fullscreen" => {
+                        let _ = app.emit("tray-capture", "fullscreen");
+                    }
+                    "capture_window" => {
+                        let _ = app.emit("tray-capture", "window");
+                    }
+                    "quit" => {
+                        app.exit(0);
+                    }
+                    _ => {}
+                })
+                .build(app)?;
+
             tracing::info!("AmeCapture initialized successfully");
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                window.hide().unwrap();
+                api.prevent_close();
+            }
         })
         .invoke_handler(tauri::generate_handler![
             commands::capture::capture,
@@ -129,6 +200,11 @@ pub fn run() {
             commands::tag::get_items_by_tag,
             commands::tag::get_all_tags_for_items,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app_handle, event| {
+            if let RunEvent::ExitRequested { api, .. } = event {
+                api.prevent_exit();
+            }
+        });
 }

--- a/src/hooks/useTrayCapture.ts
+++ b/src/hooks/useTrayCapture.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import type { CaptureAction } from './useGlobalShortcut';
+
+export function useTrayCapture(onAction: (action: CaptureAction) => void) {
+  const onActionRef = useRef(onAction);
+  onActionRef.current = onAction;
+
+  useEffect(() => {
+    const unlisten = listen<string>('tray-capture', (event) => {
+      const action = event.payload as CaptureAction;
+      if (action === 'region' || action === 'fullscreen' || action === 'window') {
+        onActionRef.current(action);
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -12,6 +12,7 @@ import { RegionCaptureOverlay } from '@/components/RegionCaptureOverlay';
 import { WindowCaptureOverlay } from '@/components/WindowCaptureOverlay';
 import { useGlobalShortcut } from '@/hooks/useGlobalShortcut';
 import type { CaptureAction } from '@/hooks/useGlobalShortcut';
+import { useTrayCapture } from '@/hooks/useTrayCapture';
 import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 import type { CaptureRegion, RegionCaptureInfo, WindowInfo } from '@/types';
@@ -48,6 +49,21 @@ export default function WorkspacePage() {
   }, []);
 
   useGlobalShortcut((action: CaptureAction) => {
+    if (regionCaptureInfo || windowCaptureList) return;
+    switch (action) {
+      case 'fullscreen':
+        handleCaptureFullscreen();
+        break;
+      case 'region':
+        handleCaptureRegion();
+        break;
+      case 'window':
+        handleCaptureWindow();
+        break;
+    }
+  });
+
+  useTrayCapture((action: CaptureAction) => {
     if (regionCaptureInfo || windowCaptureList) return;
     switch (action) {
       case 'fullscreen':


### PR DESCRIPTION
## Summary

Closes #93

- **Minimize to tray**: Window close button now hides the window to system tray instead of quitting the app
- **Tray menu with capture operations**: Region capture, fullscreen capture, and window capture can be triggered from the tray icon menu
- **Show window from tray**: "ウィンドウを表示" menu item restores and focuses the main window
- **Quit from tray**: "終了" menu item cleanly exits the application
- **Frontend tray event listener**: New `useTrayCapture` hook listens for `tray-capture` events emitted from the Rust backend and triggers the appropriate capture flow

### Acceptance Criteria
- [x] 最小化でトレイ常駐できる
- [x] トレイメニューから範囲 / 全画面 / ウィンドウが起動できる
- [x] 終了できる

### Changes
- `src-tauri/src/lib.rs`: Added system tray with menu (show, capture submenu, quit), `on_window_event` to intercept close → hide, `RunEvent::ExitRequested` prevention
- `src/hooks/useTrayCapture.ts`: New hook that listens for `tray-capture` events via `@tauri-apps/api/event`
- `src/pages/WorkspacePage.tsx`: Integrated `useTrayCapture` hook alongside existing `useGlobalShortcut`