### PR TITLE
feat: キャプチャ直後にクリップボードへ自動コピー

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -12,7 +12,6 @@ use crate::services::workspace::WorkspaceService;
 ///
 /// This serves as the DI container, holding trait-object references
 /// to all services. Services are resolved through this state in commands.
-#[allow(dead_code)]
 pub struct AppState {
     pub capture_service: Box<dyn CaptureService>,
     pub workspace_service: Box<dyn WorkspaceService>,
@@ -21,5 +20,6 @@ pub struct AppState {
     pub editor_service: Box<dyn EditorService>,
     pub thumbnail_service: Box<dyn ThumbnailService>,
     pub storage_service: Box<dyn StorageService>,
+    #[allow(dead_code)]
     pub db_conn: Arc<Mutex<rusqlite::Connection>>,
 }

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -12,6 +12,7 @@ use crate::services::workspace::WorkspaceService;
 ///
 /// This serves as the DI container, holding trait-object references
 /// to all services. Services are resolved through this state in commands.
+#[allow(dead_code)]
 pub struct AppState {
     pub capture_service: Box<dyn CaptureService>,
     pub workspace_service: Box<dyn WorkspaceService>,

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -10,18 +10,20 @@ use crate::error::CommandResult;
 use crate::models::capture::{CaptureRegion, RegionCaptureInfo, WindowCaptureInfo};
 use crate::models::workspace_item::{WorkspaceItem, WorkspaceItemType};
 
-fn copy_image_to_clipboard(app: &tauri::AppHandle, image_path: &Path) {
+fn copy_image_to_clipboard(app: &tauri::AppHandle, img: image::DynamicImage) {
+    let rgba = img.into_rgba8();
+    let (w, h) = rgba.dimensions();
+    let tauri_img = tauri::image::Image::new_owned(rgba.into_raw(), w, h);
+    if let Err(e) = app.clipboard().write_image(&tauri_img) {
+        tracing::warn!("Failed to copy image to clipboard: {e}");
+    } else {
+        tracing::info!("Image copied to clipboard after capture");
+    }
+}
+
+fn copy_path_to_clipboard(app: &tauri::AppHandle, image_path: &Path) {
     match image::open(image_path) {
-        Ok(img) => {
-            let rgba = img.to_rgba8();
-            let (w, h) = rgba.dimensions();
-            let tauri_img = tauri::image::Image::new_owned(rgba.into_raw(), w, h);
-            if let Err(e) = app.clipboard().write_image(&tauri_img) {
-                tracing::warn!("Failed to copy image to clipboard: {e}");
-            } else {
-                tracing::info!("Image copied to clipboard after capture");
-            }
-        }
+        Ok(img) => copy_image_to_clipboard(app, img),
         Err(e) => {
             tracing::warn!("Failed to load image for clipboard copy: {e}");
         }
@@ -140,7 +142,7 @@ pub fn capture(
                         capture_result.width,
                         capture_result.height
                     );
-                    copy_image_to_clipboard(&app, &original_path);
+                    copy_path_to_clipboard(&app, &original_path);
                     CommandResult::ok(item)
                 }
                 Err(e) => CommandResult::err(e.to_string()),
@@ -242,7 +244,7 @@ pub fn capture(
                         capture_result.width,
                         capture_result.height
                     );
-                    copy_image_to_clipboard(&app, &original_path);
+                    copy_path_to_clipboard(&app, &original_path);
                     CommandResult::ok(item)
                 }
                 Err(e) => CommandResult::err(e.to_string()),
@@ -444,7 +446,7 @@ pub fn finalize_region_capture(
     match state.workspace_service.add_item(&item) {
         Ok(()) => {
             tracing::info!("Region capture saved: {} ({}x{})", item.id, w, h);
-            copy_image_to_clipboard(&app, &original_path);
+            copy_image_to_clipboard(&app, cropped);
             let _ = std::fs::remove_file(&source_path);
             CommandResult::ok(item)
         }

--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -3,11 +3,30 @@ use std::time::Duration;
 
 use tauri::Manager;
 use tauri::State;
+use tauri_plugin_clipboard_manager::ClipboardExt;
 
 use crate::app_state::AppState;
 use crate::error::CommandResult;
 use crate::models::capture::{CaptureRegion, RegionCaptureInfo, WindowCaptureInfo};
 use crate::models::workspace_item::{WorkspaceItem, WorkspaceItemType};
+
+fn copy_image_to_clipboard(app: &tauri::AppHandle, image_path: &Path) {
+    match image::open(image_path) {
+        Ok(img) => {
+            let rgba = img.to_rgba8();
+            let (w, h) = rgba.dimensions();
+            let tauri_img = tauri::image::Image::new_owned(rgba.into_raw(), w, h);
+            if let Err(e) = app.clipboard().write_image(&tauri_img) {
+                tracing::warn!("Failed to copy image to clipboard: {e}");
+            } else {
+                tracing::info!("Image copied to clipboard after capture");
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to load image for clipboard copy: {e}");
+        }
+    }
+}
 
 fn validate_temp_path(source_path: &str) -> Result<(), String> {
     let path = Path::new(source_path);
@@ -39,6 +58,7 @@ fn validate_temp_path(source_path: &str) -> Result<(), String> {
 
 #[tauri::command]
 pub fn capture(
+    app: tauri::AppHandle,
     r#type: String,
     region: Option<CaptureRegion>,
     hwnd: Option<isize>,
@@ -120,6 +140,7 @@ pub fn capture(
                         capture_result.width,
                         capture_result.height
                     );
+                    copy_image_to_clipboard(&app, &original_path);
                     CommandResult::ok(item)
                 }
                 Err(e) => CommandResult::err(e.to_string()),
@@ -221,6 +242,7 @@ pub fn capture(
                         capture_result.width,
                         capture_result.height
                     );
+                    copy_image_to_clipboard(&app, &original_path);
                     CommandResult::ok(item)
                 }
                 Err(e) => CommandResult::err(e.to_string()),
@@ -302,6 +324,7 @@ pub fn prepare_region_capture(
 
 #[tauri::command]
 pub fn finalize_region_capture(
+    app: tauri::AppHandle,
     source_path: String,
     region: CaptureRegion,
     state: State<'_, AppState>,
@@ -421,6 +444,7 @@ pub fn finalize_region_capture(
     match state.workspace_service.add_item(&item) {
         Ok(()) => {
             tracing::info!("Region capture saved: {} ({}x{})", item.id, w, h);
+            copy_image_to_clipboard(&app, &original_path);
             let _ = std::fs::remove_file(&source_path);
             CommandResult::ok(item)
         }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,12 +1,14 @@
 use crate::error::AppResult;
 use crate::models::capture::WindowInfo;
 
+#[allow(dead_code)]
 pub fn enumerate_monitors() -> AppResult<Vec<MonitorInfo>> {
     tracing::debug!("Enumerating monitors (not yet implemented)");
     Ok(vec![])
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct MonitorInfo {
     pub id: u32,
     pub name: String,

--- a/src-tauri/src/repositories/settings.rs
+++ b/src-tauri/src/repositories/settings.rs
@@ -5,6 +5,7 @@ use rusqlite::params;
 use crate::error::{AppError, AppResult};
 
 /// Repository trait for settings data access
+#[allow(dead_code)]
 pub trait SettingsRepository: Send + Sync {
     fn get(&self, key: &str) -> AppResult<Option<String>>;
     fn set(&self, key: &str, value: &str) -> AppResult<()>;

--- a/src-tauri/src/repositories/settings.rs
+++ b/src-tauri/src/repositories/settings.rs
@@ -5,8 +5,8 @@ use rusqlite::params;
 use crate::error::{AppError, AppResult};
 
 /// Repository trait for settings data access
-#[allow(dead_code)]
 pub trait SettingsRepository: Send + Sync {
+    #[allow(dead_code)]
     fn get(&self, key: &str) -> AppResult<Option<String>>;
     fn set(&self, key: &str, value: &str) -> AppResult<()>;
     fn get_all(&self) -> AppResult<Vec<(String, String)>>;

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -1,6 +1,7 @@
 use crate::error::{AppError, AppResult};
 use crate::models::capture::{CaptureRegion, CaptureResult};
 
+#[allow(dead_code)]
 pub trait CaptureService: Send + Sync {
     fn capture_full_screen(&self, save_path: &str) -> AppResult<CaptureResult>;
     fn capture_region(&self, region: &CaptureRegion, save_path: &str) -> AppResult<CaptureResult>;

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -1,9 +1,9 @@
 use crate::error::{AppError, AppResult};
 use crate::models::capture::{CaptureRegion, CaptureResult};
 
-#[allow(dead_code)]
 pub trait CaptureService: Send + Sync {
     fn capture_full_screen(&self, save_path: &str) -> AppResult<CaptureResult>;
+    #[allow(dead_code)]
     fn capture_region(&self, region: &CaptureRegion, save_path: &str) -> AppResult<CaptureResult>;
     fn capture_window(&self, hwnd: isize, save_path: &str) -> AppResult<CaptureResult>;
 }

--- a/src-tauri/src/services/storage.rs
+++ b/src-tauri/src/services/storage.rs
@@ -4,6 +4,7 @@ use crate::error::AppResult;
 use crate::storage::StoragePathResolver;
 
 /// Service trait for storage path resolution and directory management.
+#[allow(dead_code)]
 pub trait StorageService: Send + Sync {
     /// Get the base save path.
     fn get_base_path(&self) -> PathBuf;

--- a/src-tauri/src/services/storage.rs
+++ b/src-tauri/src/services/storage.rs
@@ -4,9 +4,9 @@ use crate::error::AppResult;
 use crate::storage::StoragePathResolver;
 
 /// Service trait for storage path resolution and directory management.
-#[allow(dead_code)]
 pub trait StorageService: Send + Sync {
     /// Get the base save path.
+    #[allow(dead_code)]
     fn get_base_path(&self) -> PathBuf;
 
     /// Ensure all storage directories exist. Creates them if missing.

--- a/src-tauri/src/services/workspace.rs
+++ b/src-tauri/src/services/workspace.rs
@@ -4,11 +4,11 @@ use crate::error::{AppError, AppResult};
 use crate::models::workspace_item::WorkspaceItem;
 use crate::repositories::workspace::WorkspaceRepository;
 
-#[allow(dead_code)]
 pub trait WorkspaceService: Send + Sync {
     fn get_all_items(&self) -> AppResult<Vec<WorkspaceItem>>;
     fn get_item(&self, id: &str) -> AppResult<Option<WorkspaceItem>>;
     fn add_item(&self, item: &WorkspaceItem) -> AppResult<()>;
+    #[allow(dead_code)]
     fn update_item(&self, item: &WorkspaceItem) -> AppResult<()>;
     fn delete_item(&self, id: &str) -> AppResult<()>;
     fn rename_item(&self, id: &str, title: &str) -> AppResult<WorkspaceItem>;

--- a/src-tauri/src/services/workspace.rs
+++ b/src-tauri/src/services/workspace.rs
@@ -4,6 +4,7 @@ use crate::error::{AppError, AppResult};
 use crate::models::workspace_item::WorkspaceItem;
 use crate::repositories::workspace::WorkspaceRepository;
 
+#[allow(dead_code)]
 pub trait WorkspaceService: Send + Sync {
     fn get_all_items(&self) -> AppResult<Vec<WorkspaceItem>>;
     fn get_item(&self, id: &str) -> AppResult<Option<WorkspaceItem>>;


### PR DESCRIPTION
## Summary

- キャプチャ直後に画像をクリップボードへ自動コピーする機能を実装しました
- 全画面キャプチャ、範囲キャプチャ、ウィンドウキャプチャの全キャプチャタイプに対応しています
- キャプチャ成功後に `copy_image_to_clipboard` ヘルパー関数を呼び出し、自動的にクリップボードへ画像を書き込みます
- Teams、Office等の一般的なWindowsアプリへの貼り付けが可能です
- クリップボードコピーの失敗はキャプチャ自体の成功を妨げません（警告ログのみ出力）

## 変更内容

- `src-tauri/src/commands/capture.rs`: `copy_image_to_clipboard` ヘルパー関数を追加し、各キャプチャ成功後に呼び出し
- 事前定義済み trait/interface の `#[allow(dead_code)]` 追加（将来利用予定のAPI）

## 関連Issue

Closes #94