### PR TITLE
feat: implement image editor page (Issue #95)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import WorkspacePage from '@/pages/WorkspacePage';
 import EditorPage from '@/pages/EditorPage';
 import SettingsPage from '@/pages/SettingsPage';
@@ -6,12 +6,18 @@ import SettingsPage from '@/pages/SettingsPage';
 type Page = 'workspace' | 'editor' | 'settings';
 
 export default function App() {
-  const [currentPage] = useState<Page>('workspace');
+  const [currentPage, setCurrentPage] = useState<Page>('workspace');
+
+  const handleBack = useCallback(() => {
+    setCurrentPage('workspace');
+  }, []);
 
   return (
     <div className="h-screen w-screen overflow-hidden" data-tauri-drag-region>
-      {currentPage === 'workspace' && <WorkspacePage />}
-      {currentPage === 'editor' && <EditorPage />}
+      {currentPage === 'workspace' && (
+        <WorkspacePage onNavigateToEditor={() => setCurrentPage('editor')} />
+      )}
+      {currentPage === 'editor' && <EditorPage onBack={handleBack} />}
       {currentPage === 'settings' && <SettingsPage />}
     </div>
   );

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceItem } from '@/types';
 import { X, Star, Copy, FolderOpen, Trash2, Edit3, Check } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 import { TagInput } from '@/components/TagInput';
+import { useEditorStore } from '@/stores/editorStore';
 
 interface DetailPanelProps {
   item: WorkspaceItem;
@@ -13,6 +14,7 @@ interface DetailPanelProps {
   onRename: (id: string, title: string) => void;
   onShowInFolder: (id: string) => void;
   onCopyToClipboard: (id: string) => void;
+  onOpenEditor: () => void;
 }
 
 export function DetailPanel({
@@ -23,10 +25,12 @@ export function DetailPanel({
   onRename,
   onShowInFolder,
   onCopyToClipboard,
+  onOpenEditor,
 }: DetailPanelProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(item.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const setEditingItem = useEditorStore((s) => s.setEditingItem);
 
   useEffect(() => {
     setEditTitle(item.title);
@@ -142,7 +146,15 @@ export function DetailPanel({
 
       {/* Actions */}
       <div className="space-y-2">
-        <button className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent">
+        <button
+          className="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md hover:bg-accent"
+          onClick={() => {
+            if (item.type === 'image') {
+              setEditingItem(item.id);
+              onOpenEditor();
+            }
+          }}
+        >
           <Edit3 className="w-4 h-4" />
           編集
         </button>

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useRef, useState } from 'react';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { cn } from '@/lib/utils';
+
+interface EditorCanvasProps {
+  imagePath: string;
+  zoom: number;
+  panX: number;
+  panY: number;
+  onZoomChange: (zoom: number) => void;
+  onPanChange: (x: number, y: number) => void;
+  className?: string;
+}
+
+export function EditorCanvas({
+  imagePath,
+  zoom,
+  panX,
+  panY,
+  onZoomChange,
+  onPanChange,
+  className,
+}: EditorCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const [panStart, setPanStart] = useState({ x: 0, y: 0 });
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -0.1 : 0.1;
+      onZoomChange(zoom + delta);
+    },
+    [zoom, onZoomChange],
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button === 0 || e.button === 1) {
+        setIsPanning(true);
+        setPanStart({ x: e.clientX - panX, y: e.clientY - panY });
+      }
+    },
+    [panX, panY],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isPanning) return;
+      onPanChange(e.clientX - panStart.x, e.clientY - panStart.y);
+    },
+    [isPanning, panStart, onPanChange],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsPanning(false);
+  }, []);
+
+  const imageUrl = convertFileSrc(imagePath);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('relative overflow-hidden bg-muted/50', className)}
+      onWheel={handleWheel}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      style={{ cursor: isPanning ? 'grabbing' : 'grab' }}
+    >
+      <div
+        style={{
+          transform: `translate(${panX}px, ${panY}px) scale(${zoom})`,
+          transformOrigin: '0 0',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+        }}
+      >
+        <img
+          src={imageUrl}
+          alt="edit target"
+          draggable={false}
+          className="block max-w-none"
+          style={{ imageRendering: zoom > 2 ? 'pixelated' : 'auto' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { cn } from '@/lib/utils';
 
@@ -24,19 +24,33 @@ export function EditorCanvas({
   const containerRef = useRef<HTMLDivElement>(null);
   const [isPanning, setIsPanning] = useState(false);
   const [panStart, setPanStart] = useState({ x: 0, y: 0 });
+  const zoomRef = useRef(zoom);
+
+  useEffect(() => {
+    zoomRef.current = zoom;
+  }, [zoom]);
 
   const handleWheel = useCallback(
-    (e: React.WheelEvent) => {
+    (e: WheelEvent) => {
       e.preventDefault();
       const delta = e.deltaY > 0 ? -0.1 : 0.1;
-      onZoomChange(zoom + delta);
+      onZoomChange(zoomRef.current + delta);
     },
-    [zoom, onZoomChange],
+    [onZoomChange],
   );
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', handleWheel);
+    };
+  }, [handleWheel]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
-      if (e.button === 0 || e.button === 1) {
+      if (e.button === 1) {
         setIsPanning(true);
         setPanStart({ x: e.clientX - panX, y: e.clientY - panY });
       }
@@ -62,12 +76,11 @@ export function EditorCanvas({
     <div
       ref={containerRef}
       className={cn('relative overflow-hidden bg-muted/50', className)}
-      onWheel={handleWheel}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
-      style={{ cursor: isPanning ? 'grabbing' : 'grab' }}
+      style={{ cursor: isPanning ? 'grabbing' : 'default' }}
     >
       <div
         style={{

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -1,0 +1,145 @@
+import {
+  MousePointer2,
+  MoveRight,
+  Type,
+  Square,
+  Grid3x3,
+  Crop,
+  ZoomIn,
+  ZoomOut,
+  Save,
+  Copy,
+  ArrowLeft,
+  Undo2,
+  Redo2,
+} from 'lucide-react';
+import type { EditorTool } from '@/types';
+import { cn } from '@/lib/utils';
+
+interface EditorToolbarProps {
+  activeTool: EditorTool;
+  zoom: number;
+  canUndo: boolean;
+  canRedo: boolean;
+  isDirty: boolean;
+  onToolSelect: (tool: EditorTool) => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onZoomReset: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onSave: () => void;
+  onCopy: () => void;
+  onBack: () => void;
+}
+
+const tools: { tool: EditorTool; icon: React.ElementType; label: string }[] = [
+  { tool: 'select', icon: MousePointer2, label: '選択' },
+  { tool: 'arrow', icon: MoveRight, label: '矢印' },
+  { tool: 'text', icon: Type, label: 'テキスト' },
+  { tool: 'rectangle', icon: Square, label: '矩形' },
+  { tool: 'mosaic', icon: Grid3x3, label: 'モザイク' },
+  { tool: 'crop', icon: Crop, label: 'トリミング' },
+];
+
+export function EditorToolbar({
+  activeTool,
+  zoom,
+  canUndo,
+  canRedo,
+  isDirty,
+  onToolSelect,
+  onZoomIn,
+  onZoomOut,
+  onZoomReset,
+  onUndo,
+  onRedo,
+  onSave,
+  onCopy,
+  onBack,
+}: EditorToolbarProps) {
+  return (
+    <div className="flex items-center justify-between border-b border-border px-4 py-2">
+      <div className="flex items-center gap-1">
+        <button
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md hover:bg-accent"
+          onClick={onBack}
+          title="ワークスペースに戻る"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          戻る
+        </button>
+        <div className="w-px h-6 bg-border mx-2" />
+        {tools.map(({ tool, icon: Icon, label }) => (
+          <button
+            key={tool}
+            className={cn(
+              'p-1.5 rounded-md transition-colors',
+              activeTool === tool ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
+            )}
+            onClick={() => onToolSelect(tool)}
+            title={label}
+          >
+            <Icon className="w-4 h-4" />
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-1">
+        <button
+          className="p-1.5 rounded-md hover:bg-accent disabled:opacity-40"
+          onClick={onUndo}
+          disabled={!canUndo}
+          title="元に戻す"
+        >
+          <Undo2 className="w-4 h-4" />
+        </button>
+        <button
+          className="p-1.5 rounded-md hover:bg-accent disabled:opacity-40"
+          onClick={onRedo}
+          disabled={!canRedo}
+          title="やり直す"
+        >
+          <Redo2 className="w-4 h-4" />
+        </button>
+        <div className="w-px h-6 bg-border mx-2" />
+        <button className="p-1.5 rounded-md hover:bg-accent" onClick={onZoomOut} title="縮小">
+          <ZoomOut className="w-4 h-4" />
+        </button>
+        <button
+          className="px-2 py-1 text-xs rounded-md hover:bg-accent min-w-[60px] text-center"
+          onClick={onZoomReset}
+          title="ズームリセット"
+        >
+          {Math.round(zoom * 100)}%
+        </button>
+        <button className="p-1.5 rounded-md hover:bg-accent" onClick={onZoomIn} title="拡大">
+          <ZoomIn className="w-4 h-4" />
+        </button>
+        <div className="w-px h-6 bg-border mx-2" />
+        <button
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md hover:bg-accent"
+          onClick={onCopy}
+          title="クリップボードにコピー"
+        >
+          <Copy className="w-4 h-4" />
+          コピー
+        </button>
+        <button
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md',
+            isDirty
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'bg-primary/50 text-primary-foreground cursor-not-allowed',
+          )}
+          onClick={onSave}
+          disabled={!isDirty}
+          title="保存"
+        >
+          <Save className="w-4 h-4" />
+          保存
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThumbnailGrid.tsx
+++ b/src/components/ThumbnailGrid.tsx
@@ -3,6 +3,7 @@ import type { WorkspaceItem } from '@/types';
 import { Star, StarOff, Trash2, ImageIcon, Film } from 'lucide-react';
 import { MEDIA_TYPE_CONFIG } from '@/lib/mediaTypeConfig';
 import { useTagStore } from '@/stores/tagStore';
+import { useEditorStore } from '@/stores/editorStore';
 
 interface ThumbnailGridProps {
   items: WorkspaceItem[];
@@ -10,6 +11,7 @@ interface ThumbnailGridProps {
   onSelect: (ids: string[]) => void;
   onToggleFavorite: (id: string, isFavorite: boolean) => void;
   onDelete: (id: string) => void;
+  onOpenEditor: () => void;
 }
 
 export function ThumbnailGrid({
@@ -18,8 +20,10 @@ export function ThumbnailGrid({
   onSelect,
   onToggleFavorite,
   onDelete,
+  onOpenEditor,
 }: ThumbnailGridProps) {
   const itemTags = useTagStore((s) => s.itemTags);
+  const setEditingItem = useEditorStore((s) => s.setEditingItem);
 
   const handleClick = (id: string, e: React.MouseEvent) => {
     if (e.ctrlKey || e.metaKey) {
@@ -33,8 +37,10 @@ export function ThumbnailGrid({
   };
 
   const handleDoubleClick = (item: WorkspaceItem) => {
-    // TODO: Open editor with this item
-    console.log('Open editor for:', item.id);
+    if (item.type === 'image') {
+      setEditingItem(item.id);
+      onOpenEditor();
+    }
   };
 
   return (

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -1,7 +1,121 @@
-export default function EditorPage() {
+import { useCallback, useEffect } from 'react';
+import { useEditorStore } from '@/stores/editorStore';
+import { useEditor } from '@/hooks/useEditor';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { EditorToolbar } from '@/components/EditorToolbar';
+import { EditorCanvas } from '@/components/EditorCanvas';
+import { invoke } from '@tauri-apps/api/core';
+import type { CommandResult } from '@/types';
+
+interface EditorPageProps {
+  onBack: () => void;
+}
+
+export default function EditorPage({ onBack }: EditorPageProps) {
+  const editingItemId = useEditorStore((s) => s.editingItemId);
+  const activeTool = useEditorStore((s) => s.activeTool);
+  const zoom = useEditorStore((s) => s.zoom);
+  const panX = useEditorStore((s) => s.panX);
+  const panY = useEditorStore((s) => s.panY);
+  const canUndo = useEditorStore((s) => s.canUndo);
+  const canRedo = useEditorStore((s) => s.canRedo);
+  const isDirty = useEditorStore((s) => s.isDirty);
+  const setActiveTool = useEditorStore((s) => s.setActiveTool);
+  const setZoom = useEditorStore((s) => s.setZoom);
+  const setPan = useEditorStore((s) => s.setPan);
+  const resetEditor = useEditorStore((s) => s.resetEditor);
+
+  const { saveEdit, undo, redo } = useEditor();
+
+  const items = useWorkspaceStore((s) => s.items);
+  const editingItem = editingItemId ? items.find((item) => item.id === editingItemId) : null;
+
+  useEffect(() => {
+    return () => {
+      resetEditor();
+    };
+  }, [resetEditor]);
+
+  const handleZoomIn = useCallback(() => {
+    setZoom(zoom + 0.25);
+  }, [zoom, setZoom]);
+
+  const handleZoomOut = useCallback(() => {
+    setZoom(zoom - 0.25);
+  }, [zoom, setZoom]);
+
+  const handleZoomReset = useCallback(() => {
+    setZoom(1);
+    setPan(0, 0);
+  }, [setZoom, setPan]);
+
+  const handleSave = useCallback(async () => {
+    if (!editingItemId) return;
+    await saveEdit(editingItemId);
+  }, [editingItemId, saveEdit]);
+
+  const handleCopy = useCallback(async () => {
+    if (!editingItemId) return;
+    try {
+      const result = await invoke<CommandResult<null>>('copy_image_to_clipboard', {
+        id: editingItemId,
+      });
+      if (!result.success) {
+        console.error('Failed to copy image to clipboard:', result.error);
+      }
+    } catch (error) {
+      console.error('Failed to copy image to clipboard:', error);
+    }
+  }, [editingItemId]);
+
+  const handleBack = useCallback(() => {
+    resetEditor();
+    onBack();
+  }, [onBack, resetEditor]);
+
+  if (!editingItem) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="flex flex-col items-center gap-3 text-muted-foreground">
+          <p className="text-lg font-medium">画像が選択されていません</p>
+          <button
+            className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={handleBack}
+          >
+            ワークスペースに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <h1 className="text-2xl font-bold">Editor</h1>
+    <div className="flex h-full w-full flex-col">
+      <EditorToolbar
+        activeTool={activeTool}
+        zoom={zoom}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        isDirty={isDirty}
+        onToolSelect={setActiveTool}
+        onZoomIn={handleZoomIn}
+        onZoomOut={handleZoomOut}
+        onZoomReset={handleZoomReset}
+        onUndo={undo}
+        onRedo={redo}
+        onSave={handleSave}
+        onCopy={handleCopy}
+        onBack={handleBack}
+      />
+      <EditorCanvas
+        imagePath={editingItem.currentPath}
+        zoom={zoom}
+        panX={panX}
+        panY={panY}
+        onZoomChange={setZoom}
+        onPanChange={setPan}
+        className="flex-1"
+      />
     </div>
   );
 }

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -17,7 +17,11 @@ import { ImageOff, Settings, Star } from 'lucide-react';
 import { getTypeLabel } from '@/lib/mediaTypeConfig';
 import type { CaptureRegion, RegionCaptureInfo, WindowInfo } from '@/types';
 
-export default function WorkspacePage() {
+interface WorkspacePageProps {
+  onNavigateToEditor: () => void;
+}
+
+export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps) {
   const items = useWorkspaceStore((s) => s.items);
   const selectedItemIds = useWorkspaceStore((s) => s.selectedItemIds);
   const searchQuery = useWorkspaceStore((s) => s.searchQuery);
@@ -251,6 +255,7 @@ export default function WorkspacePage() {
               onSelect={handleSelect}
               onToggleFavorite={toggleFavorite}
               onDelete={deleteItem}
+              onOpenEditor={onNavigateToEditor}
             />
           )}
         </div>
@@ -265,6 +270,7 @@ export default function WorkspacePage() {
             onRename={renameItem}
             onShowInFolder={showInFolder}
             onCopyToClipboard={copyImageToClipboard}
+            onOpenEditor={onNavigateToEditor}
           />
         )}
       </div>

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -10,8 +10,11 @@ interface EditorState {
   canUndo: boolean;
   canRedo: boolean;
   isDirty: boolean;
+  zoom: number;
+  panX: number;
+  panY: number;
+  editingItemId: string | null;
 
-  // Actions
   setActiveTool: (tool: EditorTool) => void;
   setStrokeColor: (color: string) => void;
   setFillColor: (color: string) => void;
@@ -20,10 +23,14 @@ interface EditorState {
   setCanUndo: (can: boolean) => void;
   setCanRedo: (can: boolean) => void;
   setDirty: (dirty: boolean) => void;
+  setZoom: (zoom: number) => void;
+  setPan: (x: number, y: number) => void;
+  setEditingItem: (itemId: string | null) => void;
+  resetEditor: () => void;
 }
 
-export const useEditorStore = create<EditorState>((set) => ({
-  activeTool: 'select',
+const initialState = {
+  activeTool: 'select' as EditorTool,
   strokeColor: '#ff0000',
   fillColor: 'transparent',
   strokeWidth: 2,
@@ -31,6 +38,14 @@ export const useEditorStore = create<EditorState>((set) => ({
   canUndo: false,
   canRedo: false,
   isDirty: false,
+  zoom: 1,
+  panX: 0,
+  panY: 0,
+  editingItemId: null as string | null,
+};
+
+export const useEditorStore = create<EditorState>((set) => ({
+  ...initialState,
 
   setActiveTool: (tool) => set({ activeTool: tool }),
   setStrokeColor: (color) => set({ strokeColor: color }),
@@ -40,4 +55,8 @@ export const useEditorStore = create<EditorState>((set) => ({
   setCanUndo: (can) => set({ canUndo: can }),
   setCanRedo: (can) => set({ canRedo: can }),
   setDirty: (dirty) => set({ isDirty: dirty }),
+  setZoom: (zoom) => set({ zoom: Math.min(10, Math.max(0.1, zoom)) }),
+  setPan: (x, y) => set({ panX: x, panY: y }),
+  setEditingItem: (itemId) => set({ editingItemId: itemId }),
+  resetEditor: () => set(initialState),
 }));


### PR DESCRIPTION
## Summary

- 画像編集画面（EditorPage）を実装しました。画像表示、ズーム、パン、ツールバー、保存、コピー機能を備えています。
- 新規コンポーネント: `EditorCanvas`（ズーム/パン対応キャンバス）、`EditorToolbar`（ツール選択、ズーム操作、Undo/Redo、保存、コピーボタン）
- ワークスペースからの編集画面へのナビゲーションを追加（サムネイルダブルクリック、詳細パネルの編集ボタン）

Closes #95

## 変更内容

### 新規ファイル
- `src/components/EditorCanvas.tsx` - マウスホイールによるズーム、ドラッグによるパンをサポートする画像キャンバス
- `src/components/EditorToolbar.tsx` - ツール選択（選択、矢印、テキスト、矩形、モザイク、トリミング）、ズーム操作、Undo/Redo、保存、コピーボタンを備えたツールバー

### 変更ファイル
- `src/pages/EditorPage.tsx` - プレースホルダーからフル機能のエディタページに更新
- `src/stores/editorStore.ts` - ズーム、パン、編集対象アイテムIDの状態を追加
- `src/App.tsx` - ワークスペースとエディタ間のナビゲーション対応
- `src/pages/WorkspacePage.tsx` - エディタへのナビゲーションコールバックを追加
- `src/components/ThumbnailGrid.tsx` - 画像アイテムのダブルクリックでエディタを開くよう更新
- `src/components/DetailPanel.tsx` - 編集ボタンでエディタを開くよう更新

## テスト結果

- `npm run check:all` - 全てパス
- `cargo test` - 61テスト全てパス
- `cargo clippy` - エラーなし