### PR TITLE
feat: implement arrow tool for editor

### DIFF
--- a/src-tauri/src/commands/editor.rs
+++ b/src-tauri/src/commands/editor.rs
@@ -10,20 +10,55 @@ pub fn save_edit(
     state: State<'_, AppState>,
 ) -> CommandResult<String> {
     tracing::info!("Save edit requested for item: {}", item_id);
-    match state.editor_service.save_edited_image(&item_id, &edit_data) {
-        Ok(path) => CommandResult::ok(path),
-        Err(e) => CommandResult::err(e.to_string()),
+
+    let item = match state.workspace_service.get_item(&item_id) {
+        Ok(Some(item)) => item,
+        Ok(None) => return CommandResult::err(format!("Item not found: {item_id}")),
+        Err(e) => return CommandResult::err(e.to_string()),
+    };
+
+    let source_path = std::path::Path::new(&item.current_path);
+    let filename = source_path
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let output_path = state.storage_service.resolve_edited_path(&filename);
+
+    if let Err(e) = state.editor_service.apply_annotations(
+        &item.current_path,
+        &output_path.to_string_lossy(),
+        &edit_data,
+    ) {
+        return CommandResult::err(format!("Failed to apply annotations: {e}"));
     }
+
+    let mut updated = item;
+    updated.current_path = output_path.to_string_lossy().to_string();
+    updated.updated_at = chrono::Utc::now().to_rfc3339();
+
+    if let Err(e) = state.workspace_service.update_item(&updated) {
+        return CommandResult::err(format!("Failed to update item: {e}"));
+    }
+
+    if let Some(thumb_path) = &updated.thumbnail_path {
+        if let Err(e) = state
+            .thumbnail_service
+            .generate_thumbnail(&output_path.to_string_lossy(), thumb_path)
+        {
+            tracing::warn!("Failed to regenerate thumbnail: {}", e);
+        }
+    }
+
+    CommandResult::ok(output_path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
 pub fn undo(_state: State<'_, AppState>) -> CommandResult<()> {
-    // TODO: Implement undo with editor service
     CommandResult::err("Undo not yet implemented")
 }
 
 #[tauri::command]
 pub fn redo(_state: State<'_, AppState>) -> CommandResult<()> {
-    // TODO: Implement redo with editor service
     CommandResult::err("Redo not yet implemented")
 }

--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -1,7 +1,7 @@
 use std::f64::consts::PI;
 use std::path::Path;
 
-use image::{DynamicImage, Rgba, RgbaImage};
+use image::{Rgba, RgbaImage};
 use serde::Deserialize;
 
 use crate::error::{AppError, AppResult};
@@ -63,12 +63,13 @@ impl EditorService for DefaultEditorService {
     ) -> AppResult<()> {
         let edit: EditData = serde_json::from_str(annotations_json)
             .map_err(|e| AppError::Editor(format!("Invalid annotation data: {e}")))?;
-        let mut img = image::open(source_path)
+        let img = image::open(source_path)
             .map_err(|e| AppError::Editor(format!("Failed to open image: {e}")))?;
 
+        let mut rgba = img.to_rgba8();
         for annotation in &edit.annotations {
             match annotation {
-                Annotation::Arrow(arrow) => draw_arrow(&mut img, arrow),
+                Annotation::Arrow(arrow) => draw_arrow(&mut rgba, arrow),
             }
         }
 
@@ -77,7 +78,9 @@ impl EditorService for DefaultEditorService {
             std::fs::create_dir_all(parent)?;
         }
 
-        img.save(out_path)
+        let output_img = image::DynamicImage::ImageRgba8(rgba);
+        output_img
+            .save(out_path)
             .map_err(|e| AppError::Editor(format!("Failed to save image: {e}")))?;
         tracing::info!("Saved edited image to: {}", output_path);
         Ok(())
@@ -86,19 +89,21 @@ impl EditorService for DefaultEditorService {
 
 fn parse_color(color: &str) -> Rgba<u8> {
     let hex = color.trim_start_matches('#');
+    if hex.len() < 6 {
+        return Rgba([255, 0, 0, 255]);
+    }
     let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
     let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
     let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
     Rgba([r, g, b, 255])
 }
 
-fn draw_arrow(img: &mut DynamicImage, arrow: &ArrowAnnotation) {
-    let mut rgba = img.to_rgba8();
+fn draw_arrow(rgba: &mut RgbaImage, arrow: &ArrowAnnotation) {
     let color = parse_color(&arrow.stroke_color);
     let width = arrow.stroke_width.max(1);
 
     draw_thick_line(
-        &mut rgba,
+        rgba,
         arrow.start_x,
         arrow.start_y,
         arrow.end_x,
@@ -109,16 +114,7 @@ fn draw_arrow(img: &mut DynamicImage, arrow: &ArrowAnnotation) {
 
     let angle = (arrow.end_y - arrow.start_y).atan2(arrow.end_x - arrow.start_x);
     let head_length = f64::from(width) * 4.0;
-    draw_arrowhead(
-        &mut rgba,
-        arrow.end_x,
-        arrow.end_y,
-        angle,
-        head_length,
-        color,
-    );
-
-    *img = DynamicImage::ImageRgba8(rgba);
+    draw_arrowhead(rgba, arrow.end_x, arrow.end_y, angle, head_length, color);
 }
 
 fn draw_thick_line(
@@ -229,11 +225,10 @@ fn fill_triangle(img: &mut RgbaImage, tri: &Triangle, color: Rgba<u8>) {
         }
 
         if count >= 2 {
-            let (x_start, x_end) = if intersections[0] < intersections[1] {
-                (intersections[0], intersections[1])
-            } else {
-                (intersections[1], intersections[0])
-            };
+            intersections[..count]
+                .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let x_start = intersections[0];
+            let x_end = intersections[count - 1];
 
             let xs = x_start.floor() as i32;
             let xe = x_end.ceil() as i32;

--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -1,11 +1,51 @@
-use crate::error::AppResult;
+use std::f64::consts::PI;
+use std::path::Path;
 
-/// Service trait for image editing operations
-pub trait EditorService: Send + Sync {
-    fn save_edited_image(&self, source_path: &str, edit_data: &str) -> AppResult<String>;
+use image::{DynamicImage, Rgba, RgbaImage};
+use serde::Deserialize;
+
+use crate::error::{AppError, AppResult};
+
+#[derive(Deserialize)]
+struct EditData {
+    annotations: Vec<Annotation>,
 }
 
-/// Default editor service (placeholder)
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum Annotation {
+    #[serde(rename = "arrow")]
+    Arrow(ArrowAnnotation),
+}
+
+#[derive(Deserialize)]
+struct ArrowAnnotation {
+    start_x: f64,
+    start_y: f64,
+    end_x: f64,
+    end_y: f64,
+    stroke_color: String,
+    stroke_width: u32,
+}
+
+struct Triangle {
+    x0: f64,
+    y0: f64,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+}
+
+pub trait EditorService: Send + Sync {
+    fn apply_annotations(
+        &self,
+        source_path: &str,
+        output_path: &str,
+        annotations_json: &str,
+    ) -> AppResult<()>;
+}
+
 pub struct DefaultEditorService;
 
 impl DefaultEditorService {
@@ -15,13 +55,194 @@ impl DefaultEditorService {
 }
 
 impl EditorService for DefaultEditorService {
-    fn save_edited_image(&self, source_path: &str, _edit_data: &str) -> AppResult<String> {
-        tracing::info!(
-            "Save edited image requested for: {} (not yet implemented)",
-            source_path
-        );
-        Err(crate::error::AppError::Editor(
-            "Editor not yet implemented".into(),
-        ))
+    fn apply_annotations(
+        &self,
+        source_path: &str,
+        output_path: &str,
+        annotations_json: &str,
+    ) -> AppResult<()> {
+        let edit: EditData = serde_json::from_str(annotations_json)
+            .map_err(|e| AppError::Editor(format!("Invalid annotation data: {e}")))?;
+        let mut img = image::open(source_path)
+            .map_err(|e| AppError::Editor(format!("Failed to open image: {e}")))?;
+
+        for annotation in &edit.annotations {
+            match annotation {
+                Annotation::Arrow(arrow) => draw_arrow(&mut img, arrow),
+            }
+        }
+
+        let out_path = Path::new(output_path);
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        img.save(out_path)
+            .map_err(|e| AppError::Editor(format!("Failed to save image: {e}")))?;
+        tracing::info!("Saved edited image to: {}", output_path);
+        Ok(())
+    }
+}
+
+fn parse_color(color: &str) -> Rgba<u8> {
+    let hex = color.trim_start_matches('#');
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
+    Rgba([r, g, b, 255])
+}
+
+fn draw_arrow(img: &mut DynamicImage, arrow: &ArrowAnnotation) {
+    let mut rgba = img.to_rgba8();
+    let color = parse_color(&arrow.stroke_color);
+    let width = arrow.stroke_width.max(1);
+
+    draw_thick_line(
+        &mut rgba,
+        arrow.start_x,
+        arrow.start_y,
+        arrow.end_x,
+        arrow.end_y,
+        color,
+        width,
+    );
+
+    let angle = (arrow.end_y - arrow.start_y).atan2(arrow.end_x - arrow.start_x);
+    let head_length = f64::from(width) * 4.0;
+    draw_arrowhead(
+        &mut rgba,
+        arrow.end_x,
+        arrow.end_y,
+        angle,
+        head_length,
+        color,
+    );
+
+    *img = DynamicImage::ImageRgba8(rgba);
+}
+
+fn draw_thick_line(
+    img: &mut RgbaImage,
+    x0: f64,
+    y0: f64,
+    x1: f64,
+    y1: f64,
+    color: Rgba<u8>,
+    thickness: u32,
+) {
+    let dx = x1 - x0;
+    let dy = y1 - y0;
+    let length = (dx * dx + dy * dy).sqrt();
+    if length == 0.0 {
+        return;
+    }
+
+    let half = f64::from(thickness) / 2.0;
+    let steps = (length * 2.0).ceil() as u32;
+    let img_w = img.width();
+    let img_h = img.height();
+
+    for i in 0..=steps {
+        let t = f64::from(i) / f64::from(steps);
+        let cx = x0 + dx * t;
+        let cy = y0 + dy * t;
+
+        let r = half.ceil() as i32;
+        for oy in -r..=r {
+            for ox in -r..=r {
+                if f64::from(ox * ox + oy * oy) <= half * half {
+                    let px = (cx + f64::from(ox)).round() as i32;
+                    let py = (cy + f64::from(oy)).round() as i32;
+                    if px >= 0 && py >= 0 && (px as u32) < img_w && (py as u32) < img_h {
+                        img.put_pixel(px as u32, py as u32, color);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn draw_arrowhead(
+    img: &mut RgbaImage,
+    tip_x: f64,
+    tip_y: f64,
+    angle: f64,
+    size: f64,
+    color: Rgba<u8>,
+) {
+    let angle1 = angle + PI * 5.0 / 6.0;
+    let angle2 = angle - PI * 5.0 / 6.0;
+
+    let triangle = Triangle {
+        x0: tip_x,
+        y0: tip_y,
+        x1: tip_x + size * angle1.cos(),
+        y1: tip_y + size * angle1.sin(),
+        x2: tip_x + size * angle2.cos(),
+        y2: tip_y + size * angle2.sin(),
+    };
+
+    fill_triangle(img, &triangle, color);
+}
+
+fn fill_triangle(img: &mut RgbaImage, tri: &Triangle, color: Rgba<u8>) {
+    let mut vertices = [(tri.x0, tri.y0), (tri.x1, tri.y1), (tri.x2, tri.y2)];
+    vertices.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let (ax, ay) = vertices[0];
+    let (bx, by) = vertices[1];
+    let (cx, cy) = vertices[2];
+
+    let min_y = ay.floor() as i32;
+    let max_y = cy.ceil() as i32;
+    let img_w = img.width();
+    let img_h = img.height();
+    let range = 0.0..=1.0f64;
+
+    for y in min_y..=max_y {
+        let yf = f64::from(y);
+        let mut intersections: [f64; 4] = [0.0; 4];
+        let mut count = 0usize;
+
+        if (ay - cy).abs() > f64::EPSILON {
+            let t = (yf - ay) / (cy - ay);
+            if range.contains(&t) {
+                intersections[count] = ax + t * (cx - ax);
+                count += 1;
+            }
+        }
+
+        if (ay - by).abs() > f64::EPSILON {
+            let t = (yf - ay) / (by - ay);
+            if range.contains(&t) {
+                intersections[count] = ax + t * (bx - ax);
+                count += 1;
+            }
+        }
+
+        if (by - cy).abs() > f64::EPSILON {
+            let t = (yf - by) / (cy - by);
+            if range.contains(&t) {
+                intersections[count] = bx + t * (cx - bx);
+                count += 1;
+            }
+        }
+
+        if count >= 2 {
+            let (x_start, x_end) = if intersections[0] < intersections[1] {
+                (intersections[0], intersections[1])
+            } else {
+                (intersections[1], intersections[0])
+            };
+
+            let xs = x_start.floor() as i32;
+            let xe = x_end.ceil() as i32;
+
+            for x in xs..=xe {
+                if x >= 0 && y >= 0 && (x as u32) < img_w && (y as u32) < img_h {
+                    img.put_pixel(x as u32, y as u32, color);
+                }
+            }
+        }
     }
 }

--- a/src-tauri/src/services/workspace.rs
+++ b/src-tauri/src/services/workspace.rs
@@ -8,6 +8,7 @@ pub trait WorkspaceService: Send + Sync {
     fn get_all_items(&self) -> AppResult<Vec<WorkspaceItem>>;
     fn get_item(&self, id: &str) -> AppResult<Option<WorkspaceItem>>;
     fn add_item(&self, item: &WorkspaceItem) -> AppResult<()>;
+    fn update_item(&self, item: &WorkspaceItem) -> AppResult<()>;
     fn delete_item(&self, id: &str) -> AppResult<()>;
     fn rename_item(&self, id: &str, title: &str) -> AppResult<WorkspaceItem>;
     fn toggle_favorite(&self, id: &str, is_favorite: bool) -> AppResult<()>;
@@ -118,6 +119,11 @@ impl<R: WorkspaceRepository> WorkspaceService for DefaultWorkspaceService<R> {
     fn add_item(&self, item: &WorkspaceItem) -> AppResult<()> {
         tracing::info!("Adding workspace item: {} ({})", item.id, item.title);
         self.repo.add(item)
+    }
+
+    fn update_item(&self, item: &WorkspaceItem) -> AppResult<()> {
+        tracing::info!("Updating workspace item: {}", item.id);
+        self.repo.update(item)
     }
 
     fn delete_item(&self, id: &str) -> AppResult<()> {

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -1,15 +1,53 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { cn } from '@/lib/utils';
+import type { EditorAnnotation, EditorTool } from '@/types';
 
 interface EditorCanvasProps {
   imagePath: string;
   zoom: number;
   panX: number;
   panY: number;
+  activeTool: EditorTool;
+  strokeColor: string;
+  strokeWidth: number;
+  annotations: EditorAnnotation[];
   onZoomChange: (zoom: number) => void;
   onPanChange: (x: number, y: number) => void;
+  onAddAnnotation: (annotation: EditorAnnotation) => void;
   className?: string;
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2) + Date.now().toString(36);
+}
+
+function getArrowheadPoints(
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  sw: number,
+): string {
+  const dx = endX - startX;
+  const dy = endY - startY;
+  const length = Math.sqrt(dx * dx + dy * dy);
+  if (length === 0) return '';
+
+  const angle = Math.atan2(dy, dx);
+  const headLength = sw * 4;
+  const headWidth = sw * 2;
+
+  const baseX = endX - headLength * Math.cos(angle);
+  const baseY = endY - headLength * Math.sin(angle);
+
+  const leftX = baseX + headWidth * Math.cos(angle - Math.PI / 2);
+  const leftY = baseY + headWidth * Math.sin(angle - Math.PI / 2);
+
+  const rightX = baseX + headWidth * Math.cos(angle + Math.PI / 2);
+  const rightY = baseY + headWidth * Math.sin(angle + Math.PI / 2);
+
+  return `${endX},${endY} ${leftX},${leftY} ${rightX},${rightY}`;
 }
 
 export function EditorCanvas({
@@ -17,18 +55,42 @@ export function EditorCanvas({
   zoom,
   panX,
   panY,
+  activeTool,
+  strokeColor,
+  strokeWidth,
+  annotations,
   onZoomChange,
   onPanChange,
+  onAddAnnotation,
   className,
 }: EditorCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
   const [isPanning, setIsPanning] = useState(false);
   const [panStart, setPanStart] = useState({ x: 0, y: 0 });
-  const zoomRef = useRef(zoom);
+  const [imgSize, setImgSize] = useState({ width: 0, height: 0 });
+  const [drawing, setDrawing] = useState<{
+    startX: number;
+    startY: number;
+    endX: number;
+    endY: number;
+  } | null>(null);
 
+  const zoomRef = useRef(zoom);
   useEffect(() => {
     zoomRef.current = zoom;
   }, [zoom]);
+
+  const getImageCoords = useCallback(
+    (e: React.MouseEvent): { x: number; y: number } | null => {
+      if (!containerRef.current) return null;
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = (e.clientX - rect.left - panX) / zoom;
+      const y = (e.clientY - rect.top - panY) / zoom;
+      return { x, y };
+    },
+    [panX, panY, zoom],
+  );
 
   const handleWheel = useCallback(
     (e: WheelEvent) => {
@@ -53,22 +115,61 @@ export function EditorCanvas({
       if (e.button === 1) {
         setIsPanning(true);
         setPanStart({ x: e.clientX - panX, y: e.clientY - panY });
+        return;
+      }
+      if (e.button === 0 && activeTool === 'arrow') {
+        const coords = getImageCoords(e);
+        if (coords) {
+          setDrawing({
+            startX: coords.x,
+            startY: coords.y,
+            endX: coords.x,
+            endY: coords.y,
+          });
+        }
       }
     },
-    [panX, panY],
+    [panX, panY, activeTool, getImageCoords],
   );
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
-      if (!isPanning) return;
-      onPanChange(e.clientX - panStart.x, e.clientY - panStart.y);
+      if (isPanning) {
+        onPanChange(e.clientX - panStart.x, e.clientY - panStart.y);
+        return;
+      }
+      if (drawing) {
+        const coords = getImageCoords(e);
+        if (coords) {
+          setDrawing((prev) => (prev ? { ...prev, endX: coords.x, endY: coords.y } : null));
+        }
+      }
     },
-    [isPanning, panStart, onPanChange],
+    [isPanning, panStart, onPanChange, drawing, getImageCoords],
   );
 
   const handleMouseUp = useCallback(() => {
+    if (drawing) {
+      const dx = drawing.endX - drawing.startX;
+      const dy = drawing.endY - drawing.startY;
+      if (Math.sqrt(dx * dx + dy * dy) > 5) {
+        onAddAnnotation({
+          id: generateId(),
+          type: 'arrow',
+          startX: drawing.startX,
+          startY: drawing.startY,
+          endX: drawing.endX,
+          endY: drawing.endY,
+          strokeColor,
+          strokeWidth,
+        });
+      }
+      setDrawing(null);
+    }
     setIsPanning(false);
-  }, []);
+  }, [drawing, strokeColor, strokeWidth, onAddAnnotation]);
+
+  const cursor = isPanning ? 'grabbing' : activeTool === 'arrow' ? 'crosshair' : 'default';
 
   const imageUrl = convertFileSrc(imagePath);
 
@@ -80,7 +181,7 @@ export function EditorCanvas({
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
-      style={{ cursor: isPanning ? 'grabbing' : 'default' }}
+      style={{ cursor }}
     >
       <div
         style={{
@@ -92,12 +193,80 @@ export function EditorCanvas({
         }}
       >
         <img
+          ref={imgRef}
           src={imageUrl}
           alt="edit target"
           draggable={false}
           className="block max-w-none"
           style={{ imageRendering: zoom > 2 ? 'pixelated' : 'auto' }}
+          onLoad={() => {
+            if (imgRef.current) {
+              setImgSize({
+                width: imgRef.current.naturalWidth,
+                height: imgRef.current.naturalHeight,
+              });
+            }
+          }}
         />
+        {imgSize.width > 0 && imgSize.height > 0 && (
+          <svg
+            width={imgSize.width}
+            height={imgSize.height}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              pointerEvents: 'none',
+            }}
+          >
+            {annotations.map((ann) => (
+              <g key={ann.id}>
+                <line
+                  x1={ann.startX}
+                  y1={ann.startY}
+                  x2={ann.endX}
+                  y2={ann.endY}
+                  stroke={ann.strokeColor}
+                  strokeWidth={ann.strokeWidth}
+                  strokeLinecap="round"
+                />
+                <polygon
+                  points={getArrowheadPoints(
+                    ann.startX,
+                    ann.startY,
+                    ann.endX,
+                    ann.endY,
+                    ann.strokeWidth,
+                  )}
+                  fill={ann.strokeColor}
+                />
+              </g>
+            ))}
+            {drawing && (
+              <g>
+                <line
+                  x1={drawing.startX}
+                  y1={drawing.startY}
+                  x2={drawing.endX}
+                  y2={drawing.endY}
+                  stroke={strokeColor}
+                  strokeWidth={strokeWidth}
+                  strokeLinecap="round"
+                />
+                <polygon
+                  points={getArrowheadPoints(
+                    drawing.startX,
+                    drawing.startY,
+                    drawing.endX,
+                    drawing.endY,
+                    strokeWidth,
+                  )}
+                  fill={strokeColor}
+                />
+              </g>
+            )}
+          </svg>
+        )}
       </div>
     </div>
   );

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -22,6 +22,8 @@ interface EditorToolbarProps {
   canUndo: boolean;
   canRedo: boolean;
   isDirty: boolean;
+  strokeColor: string;
+  strokeWidth: number;
   onToolSelect: (tool: EditorTool) => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
@@ -31,6 +33,8 @@ interface EditorToolbarProps {
   onSave: () => void;
   onCopy: () => void;
   onBack: () => void;
+  onStrokeColorChange: (color: string) => void;
+  onStrokeWidthChange: (width: number) => void;
 }
 
 const tools: { tool: EditorTool; icon: React.ElementType; label: string }[] = [
@@ -42,12 +46,20 @@ const tools: { tool: EditorTool; icon: React.ElementType; label: string }[] = [
   { tool: 'crop', icon: Crop, label: 'トリミング' },
 ];
 
+const strokeWidths = [
+  { value: 1, label: '細' },
+  { value: 3, label: '中' },
+  { value: 5, label: '太' },
+];
+
 export function EditorToolbar({
   activeTool,
   zoom,
   canUndo,
   canRedo,
   isDirty,
+  strokeColor,
+  strokeWidth,
   onToolSelect,
   onZoomIn,
   onZoomOut,
@@ -57,7 +69,11 @@ export function EditorToolbar({
   onSave,
   onCopy,
   onBack,
+  onStrokeColorChange,
+  onStrokeWidthChange,
 }: EditorToolbarProps) {
+  const isDrawingTool = activeTool === 'arrow' || activeTool === 'rectangle';
+
   return (
     <div className="flex items-center justify-between border-b border-border px-4 py-2">
       <div className="flex items-center gap-1">
@@ -83,6 +99,35 @@ export function EditorToolbar({
             <Icon className="w-4 h-4" />
           </button>
         ))}
+        {isDrawingTool && (
+          <>
+            <div className="w-px h-6 bg-border mx-2" />
+            <input
+              type="color"
+              value={strokeColor}
+              onChange={(e) => onStrokeColorChange(e.target.value)}
+              className="w-6 h-6 rounded cursor-pointer border border-border"
+              title="色"
+            />
+            <div className="flex items-center gap-0.5">
+              {strokeWidths.map(({ value, label }) => (
+                <button
+                  key={value}
+                  className={cn(
+                    'px-1.5 py-0.5 text-xs rounded transition-colors',
+                    strokeWidth === value
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-accent text-muted-foreground',
+                  )}
+                  onClick={() => onStrokeWidthChange(value)}
+                  title={label}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
       </div>
 
       <div className="flex items-center gap-1">

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -7,8 +7,10 @@ export function useEditor() {
 
   const saveEdit = async (itemId: string) => {
     try {
+      const editData = JSON.stringify({ annotations: store.annotations });
       const result = await invoke<CommandResult<string>>('save_edit', {
         itemId,
+        editData,
       });
       if (result.success) {
         store.setDirty(false);
@@ -20,26 +22,12 @@ export function useEditor() {
     }
   };
 
-  const undo = async () => {
-    try {
-      const result = await invoke<CommandResult<null>>('undo');
-      if (result.success) {
-        // Backend will return updated state
-      }
-    } catch (error) {
-      console.error('Undo failed:', error);
-    }
+  const undo = () => {
+    store.undoAnnotations();
   };
 
-  const redo = async () => {
-    try {
-      const result = await invoke<CommandResult<null>>('redo');
-      if (result.success) {
-        // Backend will return updated state
-      }
-    } catch (error) {
-      console.error('Redo failed:', error);
-    }
+  const redo = () => {
+    store.redoAnnotations();
   };
 
   return {

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -5,7 +5,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { EditorToolbar } from '@/components/EditorToolbar';
 import { EditorCanvas } from '@/components/EditorCanvas';
 import { invoke } from '@tauri-apps/api/core';
-import type { CommandResult } from '@/types';
+import type { CommandResult, EditorAnnotation } from '@/types';
 
 interface EditorPageProps {
   onBack: () => void;
@@ -20,9 +20,15 @@ export default function EditorPage({ onBack }: EditorPageProps) {
   const canUndo = useEditorStore((s) => s.canUndo);
   const canRedo = useEditorStore((s) => s.canRedo);
   const isDirty = useEditorStore((s) => s.isDirty);
+  const strokeColor = useEditorStore((s) => s.strokeColor);
+  const strokeWidth = useEditorStore((s) => s.strokeWidth);
+  const annotations = useEditorStore((s) => s.annotations);
   const setActiveTool = useEditorStore((s) => s.setActiveTool);
   const setZoom = useEditorStore((s) => s.setZoom);
   const setPan = useEditorStore((s) => s.setPan);
+  const setStrokeColor = useEditorStore((s) => s.setStrokeColor);
+  const setStrokeWidth = useEditorStore((s) => s.setStrokeWidth);
+  const addAnnotation = useEditorStore((s) => s.addAnnotation);
   const resetEditor = useEditorStore((s) => s.resetEditor);
 
   const { saveEdit, undo, redo } = useEditor();
@@ -73,6 +79,13 @@ export default function EditorPage({ onBack }: EditorPageProps) {
     onBack();
   }, [onBack, resetEditor]);
 
+  const handleAddAnnotation = useCallback(
+    (annotation: EditorAnnotation) => {
+      addAnnotation(annotation);
+    },
+    [addAnnotation],
+  );
+
   if (!editingItem) {
     return (
       <div className="flex h-full w-full items-center justify-center">
@@ -97,6 +110,8 @@ export default function EditorPage({ onBack }: EditorPageProps) {
         canUndo={canUndo}
         canRedo={canRedo}
         isDirty={isDirty}
+        strokeColor={strokeColor}
+        strokeWidth={strokeWidth}
         onToolSelect={setActiveTool}
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}
@@ -106,14 +121,21 @@ export default function EditorPage({ onBack }: EditorPageProps) {
         onSave={handleSave}
         onCopy={handleCopy}
         onBack={handleBack}
+        onStrokeColorChange={setStrokeColor}
+        onStrokeWidthChange={setStrokeWidth}
       />
       <EditorCanvas
         imagePath={editingItem.currentPath}
         zoom={zoom}
         panX={panX}
         panY={panY}
+        activeTool={activeTool}
+        strokeColor={strokeColor}
+        strokeWidth={strokeWidth}
+        annotations={annotations}
         onZoomChange={setZoom}
         onPanChange={setPan}
+        onAddAnnotation={handleAddAnnotation}
         className="flex-1"
       />
     </div>

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { EditorTool } from '@/types';
+import type { EditorAnnotation, EditorTool } from '@/types';
 
 interface EditorState {
   activeTool: EditorTool;
@@ -14,6 +14,9 @@ interface EditorState {
   panX: number;
   panY: number;
   editingItemId: string | null;
+  annotations: EditorAnnotation[];
+  annotationPast: EditorAnnotation[][];
+  annotationFuture: EditorAnnotation[][];
 
   setActiveTool: (tool: EditorTool) => void;
   setStrokeColor: (color: string) => void;
@@ -27,6 +30,11 @@ interface EditorState {
   setPan: (x: number, y: number) => void;
   setEditingItem: (itemId: string | null) => void;
   resetEditor: () => void;
+  addAnnotation: (annotation: EditorAnnotation) => void;
+  removeAnnotation: (id: string) => void;
+  clearAnnotations: () => void;
+  undoAnnotations: () => void;
+  redoAnnotations: () => void;
 }
 
 const initialState = {
@@ -42,6 +50,9 @@ const initialState = {
   panX: 0,
   panY: 0,
   editingItemId: null as string | null,
+  annotations: [] as EditorAnnotation[],
+  annotationPast: [] as EditorAnnotation[][],
+  annotationFuture: [] as EditorAnnotation[][],
 };
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -59,4 +70,70 @@ export const useEditorStore = create<EditorState>((set) => ({
   setPan: (x, y) => set({ panX: x, panY: y }),
   setEditingItem: (itemId) => set({ editingItemId: itemId }),
   resetEditor: () => set(initialState),
+
+  addAnnotation: (annotation) =>
+    set((state) => {
+      const newAnnotations = [...state.annotations, annotation];
+      return {
+        annotationPast: [...state.annotationPast, state.annotations],
+        annotationFuture: [],
+        annotations: newAnnotations,
+        isDirty: true,
+        canUndo: true,
+        canRedo: false,
+      };
+    }),
+
+  removeAnnotation: (id) =>
+    set((state) => {
+      const newAnnotations = state.annotations.filter((a) => a.id !== id);
+      return {
+        annotationPast: [...state.annotationPast, state.annotations],
+        annotationFuture: [],
+        annotations: newAnnotations,
+        isDirty: newAnnotations.length > 0,
+        canUndo: true,
+        canRedo: false,
+      };
+    }),
+
+  clearAnnotations: () =>
+    set({
+      annotations: [],
+      annotationPast: [],
+      annotationFuture: [],
+      isDirty: false,
+      canUndo: false,
+      canRedo: false,
+    }),
+
+  undoAnnotations: () =>
+    set((state) => {
+      if (state.annotationPast.length === 0) return state;
+      const previous = state.annotationPast[state.annotationPast.length - 1] ?? [];
+      const newPast = state.annotationPast.slice(0, -1);
+      return {
+        annotations: previous,
+        annotationPast: newPast,
+        annotationFuture: [...state.annotationFuture, state.annotations],
+        isDirty: previous.length > 0,
+        canUndo: newPast.length > 0,
+        canRedo: true,
+      };
+    }),
+
+  redoAnnotations: () =>
+    set((state) => {
+      if (state.annotationFuture.length === 0) return state;
+      const next = state.annotationFuture[state.annotationFuture.length - 1] ?? [];
+      const newFuture = state.annotationFuture.slice(0, -1);
+      return {
+        annotations: next,
+        annotationPast: [...state.annotationPast, state.annotations],
+        annotationFuture: newFuture,
+        isDirty: next.length > 0,
+        canUndo: true,
+        canRedo: newFuture.length > 0,
+      };
+    }),
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,19 @@ export interface WindowCaptureInfo {
 
 export type EditorTool = 'select' | 'arrow' | 'text' | 'rectangle' | 'mosaic' | 'crop';
 
+export interface ArrowAnnotation {
+  id: string;
+  type: 'arrow';
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  strokeColor: string;
+  strokeWidth: number;
+}
+
+export type EditorAnnotation = ArrowAnnotation;
+
 export interface EditorState {
   activeTool: EditorTool;
   strokeColor: string;


### PR DESCRIPTION
## Summary
- Implement arrow drawing tool with drag-to-draw on the editor canvas using SVG overlay
- Add color picker and stroke width controls (thin/medium/thick) to the toolbar when drawing tools are active
- Implement backend image annotation rendering: arrows are drawn directly onto the saved image using the `image` crate (Bresenham line + filled triangle arrowhead)
- Add annotation-based undo/redo on the frontend with history stack
- Wire save flow: annotations are serialized and sent to backend, which applies them to the image, updates workspace item, and regenerates thumbnail

Closes #96