### PR TITLE
feat: implement text tool with font size control

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,8 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 image = "0.25"
+imageproc = "0.25"
+ab_glyph = "0.2"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -1,7 +1,9 @@
 use std::f64::consts::PI;
 use std::path::Path;
 
+use ab_glyph::{FontRef, PxScale};
 use image::{Rgba, RgbaImage};
+use imageproc::drawing::draw_text_mut;
 use serde::Deserialize;
 
 use crate::error::{AppError, AppResult};
@@ -16,6 +18,8 @@ struct EditData {
 enum Annotation {
     #[serde(rename = "arrow")]
     Arrow(ArrowAnnotation),
+    #[serde(rename = "text")]
+    Text(TextAnnotation),
 }
 
 #[derive(Deserialize)]
@@ -26,6 +30,15 @@ struct ArrowAnnotation {
     end_y: f64,
     stroke_color: String,
     stroke_width: u32,
+}
+
+#[derive(Deserialize)]
+struct TextAnnotation {
+    x: f64,
+    y: f64,
+    text: String,
+    font_size: f64,
+    stroke_color: String,
 }
 
 struct Triangle {
@@ -70,6 +83,7 @@ impl EditorService for DefaultEditorService {
         for annotation in &edit.annotations {
             match annotation {
                 Annotation::Arrow(arrow) => draw_arrow(&mut rgba, arrow),
+                Annotation::Text(text) => draw_text_annotation(&mut rgba, text),
             }
         }
 
@@ -96,6 +110,58 @@ fn parse_color(color: &str) -> Rgba<u8> {
     let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
     let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
     Rgba([r, g, b, 255])
+}
+
+fn draw_text_annotation(rgba: &mut RgbaImage, text_ann: &TextAnnotation) {
+    let font_paths = [
+        "C:\\Windows\\Fonts\\arial.ttf",
+        "C:\\Windows\\Fonts\\segoeui.ttf",
+        "C:\\Windows\\Fonts\\meiryo.ttc",
+    ];
+
+    let font_data = font_paths
+        .iter()
+        .find_map(|p| std::fs::read(p).ok())
+        .unwrap_or_else(|| {
+            tracing::error!("No suitable font found on system");
+            Vec::new()
+        });
+
+    if font_data.is_empty() {
+        return;
+    }
+
+    let font = match FontRef::try_from_slice(&font_data) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::error!("Failed to load font: {}", e);
+            return;
+        }
+    };
+
+    let scale = PxScale {
+        x: text_ann.font_size as f32,
+        y: text_ann.font_size as f32,
+    };
+    let color = parse_color(&text_ann.stroke_color);
+
+    let mut draw_img = rgba.clone();
+    let mut y_offset = 0i32;
+
+    for line in text_ann.text.split('\n') {
+        draw_text_mut(
+            &mut draw_img,
+            color,
+            text_ann.x as i32,
+            text_ann.y as i32 + y_offset,
+            scale,
+            &font,
+            line,
+        );
+        y_offset += text_ann.font_size as i32;
+    }
+
+    *rgba = draw_img;
 }
 
 fn draw_arrow(rgba: &mut RgbaImage, arrow: &ArrowAnnotation) {

--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -23,6 +23,7 @@ enum Annotation {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ArrowAnnotation {
     start_x: f64,
     start_y: f64,
@@ -33,6 +34,7 @@ struct ArrowAnnotation {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TextAnnotation {
     x: f64,
     y: f64,
@@ -80,10 +82,13 @@ impl EditorService for DefaultEditorService {
             .map_err(|e| AppError::Editor(format!("Failed to open image: {e}")))?;
 
         let mut rgba = img.to_rgba8();
+        let font_data = load_system_font();
         for annotation in &edit.annotations {
             match annotation {
                 Annotation::Arrow(arrow) => draw_arrow(&mut rgba, arrow),
-                Annotation::Text(text) => draw_text_annotation(&mut rgba, text),
+                Annotation::Text(text) => {
+                    draw_text_annotation(&mut rgba, text, font_data.as_deref())
+                }
             }
         }
 
@@ -112,26 +117,40 @@ fn parse_color(color: &str) -> Rgba<u8> {
     Rgba([r, g, b, 255])
 }
 
-fn draw_text_annotation(rgba: &mut RgbaImage, text_ann: &TextAnnotation) {
-    let font_paths = [
-        "C:\\Windows\\Fonts\\arial.ttf",
-        "C:\\Windows\\Fonts\\segoeui.ttf",
-        "C:\\Windows\\Fonts\\meiryo.ttc",
-    ];
+fn load_system_font() -> Option<Vec<u8>> {
+    let font_paths: &[&str] = if cfg!(target_os = "windows") {
+        &[
+            "C:\\Windows\\Fonts\\arial.ttf",
+            "C:\\Windows\\Fonts\\segoeui.ttf",
+            "C:\\Windows\\Fonts\\meiryo.ttc",
+        ]
+    } else if cfg!(target_os = "macos") {
+        &[
+            "/System/Library/Fonts/Helvetica.ttc",
+            "/System/Library/Fonts/SFNSMono.ttf",
+            "/Library/Fonts/Arial.ttf",
+        ]
+    } else {
+        &[
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/TTF/DejaVuSans.ttf",
+        ]
+    };
 
-    let font_data = font_paths
-        .iter()
-        .find_map(|p| std::fs::read(p).ok())
-        .unwrap_or_else(|| {
+    font_paths.iter().find_map(|p| std::fs::read(p).ok())
+}
+
+fn draw_text_annotation(rgba: &mut RgbaImage, text_ann: &TextAnnotation, font_data: Option<&[u8]>) {
+    let font_data = match font_data {
+        Some(d) => d,
+        None => {
             tracing::error!("No suitable font found on system");
-            Vec::new()
-        });
+            return;
+        }
+    };
 
-    if font_data.is_empty() {
-        return;
-    }
-
-    let font = match FontRef::try_from_slice(&font_data) {
+    let font = match FontRef::try_from_slice(font_data) {
         Ok(f) => f,
         Err(e) => {
             tracing::error!("Failed to load font: {}", e);
@@ -145,23 +164,20 @@ fn draw_text_annotation(rgba: &mut RgbaImage, text_ann: &TextAnnotation) {
     };
     let color = parse_color(&text_ann.stroke_color);
 
-    let mut draw_img = rgba.clone();
     let mut y_offset = 0i32;
 
     for line in text_ann.text.split('\n') {
         draw_text_mut(
-            &mut draw_img,
+            rgba,
             color,
             text_ann.x as i32,
-            text_ann.y as i32 + y_offset,
+            (text_ann.y - text_ann.font_size) as i32 + y_offset,
             scale,
             &font,
             line,
         );
         y_offset += text_ann.font_size as i32;
     }
-
-    *rgba = draw_img;
 }
 
 fn draw_arrow(rgba: &mut RgbaImage, arrow: &ArrowAnnotation) {

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -11,6 +11,7 @@ interface EditorCanvasProps {
   activeTool: EditorTool;
   strokeColor: string;
   strokeWidth: number;
+  fontSize: number;
   annotations: EditorAnnotation[];
   onZoomChange: (zoom: number) => void;
   onPanChange: (x: number, y: number) => void;
@@ -58,6 +59,7 @@ export function EditorCanvas({
   activeTool,
   strokeColor,
   strokeWidth,
+  fontSize,
   annotations,
   onZoomChange,
   onPanChange,
@@ -66,6 +68,7 @@ export function EditorCanvas({
 }: EditorCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
+  const textInputRef = useRef<HTMLInputElement>(null);
   const [isPanning, setIsPanning] = useState(false);
   const [panStart, setPanStart] = useState({ x: 0, y: 0 });
   const [imgSize, setImgSize] = useState({ width: 0, height: 0 });
@@ -74,6 +77,11 @@ export function EditorCanvas({
     startY: number;
     endX: number;
     endY: number;
+  } | null>(null);
+  const [textInput, setTextInput] = useState<{
+    x: number;
+    y: number;
+    value: string;
   } | null>(null);
 
   const zoomRef = useRef(zoom);
@@ -110,6 +118,27 @@ export function EditorCanvas({
     };
   }, [handleWheel]);
 
+  useEffect(() => {
+    if (textInput && textInputRef.current) {
+      textInputRef.current.focus();
+    }
+  }, [textInput]);
+
+  const commitText = useCallback(() => {
+    if (textInput && textInput.value.trim()) {
+      onAddAnnotation({
+        id: generateId(),
+        type: 'text',
+        x: textInput.x,
+        y: textInput.y,
+        text: textInput.value.trim(),
+        fontSize,
+        strokeColor,
+      });
+    }
+    setTextInput(null);
+  }, [textInput, fontSize, strokeColor, onAddAnnotation]);
+
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       if (e.button === 1) {
@@ -128,8 +157,18 @@ export function EditorCanvas({
           });
         }
       }
+      if (e.button === 0 && activeTool === 'text') {
+        if (textInput) {
+          commitText();
+          return;
+        }
+        const coords = getImageCoords(e);
+        if (coords) {
+          setTextInput({ x: coords.x, y: coords.y, value: '' });
+        }
+      }
     },
-    [panX, panY, activeTool, getImageCoords],
+    [panX, panY, activeTool, getImageCoords, textInput, commitText],
   );
 
   const handleMouseMove = useCallback(
@@ -169,7 +208,24 @@ export function EditorCanvas({
     setIsPanning(false);
   }, [drawing, strokeColor, strokeWidth, onAddAnnotation]);
 
-  const cursor = isPanning ? 'grabbing' : activeTool === 'arrow' ? 'crosshair' : 'default';
+  const handleTextKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        commitText();
+      } else if (e.key === 'Escape') {
+        setTextInput(null);
+      }
+    },
+    [commitText],
+  );
+
+  const cursor = isPanning
+    ? 'grabbing'
+    : activeTool === 'arrow'
+      ? 'crosshair'
+      : activeTool === 'text'
+        ? 'text'
+        : 'default';
 
   const imageUrl = convertFileSrc(imagePath);
 
@@ -219,29 +275,49 @@ export function EditorCanvas({
               pointerEvents: 'none',
             }}
           >
-            {annotations.map((ann) => (
-              <g key={ann.id}>
-                <line
-                  x1={ann.startX}
-                  y1={ann.startY}
-                  x2={ann.endX}
-                  y2={ann.endY}
-                  stroke={ann.strokeColor}
-                  strokeWidth={ann.strokeWidth}
-                  strokeLinecap="round"
-                />
-                <polygon
-                  points={getArrowheadPoints(
-                    ann.startX,
-                    ann.startY,
-                    ann.endX,
-                    ann.endY,
-                    ann.strokeWidth,
-                  )}
-                  fill={ann.strokeColor}
-                />
-              </g>
-            ))}
+            {annotations.map((ann) => {
+              if (ann.type === 'arrow') {
+                return (
+                  <g key={ann.id}>
+                    <line
+                      x1={ann.startX}
+                      y1={ann.startY}
+                      x2={ann.endX}
+                      y2={ann.endY}
+                      stroke={ann.strokeColor}
+                      strokeWidth={ann.strokeWidth}
+                      strokeLinecap="round"
+                    />
+                    <polygon
+                      points={getArrowheadPoints(
+                        ann.startX,
+                        ann.startY,
+                        ann.endX,
+                        ann.endY,
+                        ann.strokeWidth,
+                      )}
+                      fill={ann.strokeColor}
+                    />
+                  </g>
+                );
+              }
+              if (ann.type === 'text') {
+                return (
+                  <text
+                    key={ann.id}
+                    x={ann.x}
+                    y={ann.y}
+                    fontSize={ann.fontSize}
+                    fill={ann.strokeColor}
+                    dominantBaseline="auto"
+                    style={{ userSelect: 'none' }}
+                  >
+                    {ann.text}
+                  </text>
+                );
+              }
+              return null;
+            })}
             {drawing && (
               <g>
                 <line
@@ -266,6 +342,28 @@ export function EditorCanvas({
               </g>
             )}
           </svg>
+        )}
+        {textInput && imgSize.width > 0 && (
+          <input
+            ref={textInputRef}
+            type="text"
+            value={textInput.value}
+            onChange={(e) =>
+              setTextInput((prev) => (prev ? { ...prev, value: e.target.value } : null))
+            }
+            onKeyDown={handleTextKeyDown}
+            onBlur={commitText}
+            className="border-none bg-transparent outline-none"
+            style={{
+              position: 'absolute',
+              left: textInput.x,
+              top: textInput.y - fontSize,
+              fontSize: `${fontSize}px`,
+              color: strokeColor,
+              minWidth: '50px',
+              caretColor: strokeColor,
+            }}
+          />
         )}
       </div>
     </div>

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -24,6 +24,7 @@ interface EditorToolbarProps {
   isDirty: boolean;
   strokeColor: string;
   strokeWidth: number;
+  fontSize: number;
   onToolSelect: (tool: EditorTool) => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
@@ -35,6 +36,7 @@ interface EditorToolbarProps {
   onBack: () => void;
   onStrokeColorChange: (color: string) => void;
   onStrokeWidthChange: (width: number) => void;
+  onFontSizeChange: (size: number) => void;
 }
 
 const tools: { tool: EditorTool; icon: React.ElementType; label: string }[] = [
@@ -52,6 +54,14 @@ const strokeWidths = [
   { value: 5, label: '太' },
 ];
 
+const fontSizes = [
+  { value: 12, label: '12' },
+  { value: 16, label: '16' },
+  { value: 24, label: '24' },
+  { value: 32, label: '32' },
+  { value: 48, label: '48' },
+];
+
 export function EditorToolbar({
   activeTool,
   zoom,
@@ -60,6 +70,7 @@ export function EditorToolbar({
   isDirty,
   strokeColor,
   strokeWidth,
+  fontSize,
   onToolSelect,
   onZoomIn,
   onZoomOut,
@@ -71,8 +82,10 @@ export function EditorToolbar({
   onBack,
   onStrokeColorChange,
   onStrokeWidthChange,
+  onFontSizeChange,
 }: EditorToolbarProps) {
   const isDrawingTool = activeTool === 'arrow' || activeTool === 'rectangle';
+  const isTextTool = activeTool === 'text';
 
   return (
     <div className="flex items-center justify-between border-b border-border px-4 py-2">
@@ -121,6 +134,35 @@ export function EditorToolbar({
                   )}
                   onClick={() => onStrokeWidthChange(value)}
                   title={label}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+        {isTextTool && (
+          <>
+            <div className="w-px h-6 bg-border mx-2" />
+            <input
+              type="color"
+              value={strokeColor}
+              onChange={(e) => onStrokeColorChange(e.target.value)}
+              className="w-6 h-6 rounded cursor-pointer border border-border"
+              title="色"
+            />
+            <div className="flex items-center gap-0.5">
+              {fontSizes.map(({ value, label }) => (
+                <button
+                  key={value}
+                  className={cn(
+                    'px-1.5 py-0.5 text-xs rounded transition-colors',
+                    fontSize === value
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-accent text-muted-foreground',
+                  )}
+                  onClick={() => onFontSizeChange(value)}
+                  title={`${label}px`}
                 >
                   {label}
                 </button>

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -22,12 +22,14 @@ export default function EditorPage({ onBack }: EditorPageProps) {
   const isDirty = useEditorStore((s) => s.isDirty);
   const strokeColor = useEditorStore((s) => s.strokeColor);
   const strokeWidth = useEditorStore((s) => s.strokeWidth);
+  const fontSize = useEditorStore((s) => s.fontSize);
   const annotations = useEditorStore((s) => s.annotations);
   const setActiveTool = useEditorStore((s) => s.setActiveTool);
   const setZoom = useEditorStore((s) => s.setZoom);
   const setPan = useEditorStore((s) => s.setPan);
   const setStrokeColor = useEditorStore((s) => s.setStrokeColor);
   const setStrokeWidth = useEditorStore((s) => s.setStrokeWidth);
+  const setFontSize = useEditorStore((s) => s.setFontSize);
   const addAnnotation = useEditorStore((s) => s.addAnnotation);
   const resetEditor = useEditorStore((s) => s.resetEditor);
 
@@ -112,6 +114,7 @@ export default function EditorPage({ onBack }: EditorPageProps) {
         isDirty={isDirty}
         strokeColor={strokeColor}
         strokeWidth={strokeWidth}
+        fontSize={fontSize}
         onToolSelect={setActiveTool}
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}
@@ -123,6 +126,7 @@ export default function EditorPage({ onBack }: EditorPageProps) {
         onBack={handleBack}
         onStrokeColorChange={setStrokeColor}
         onStrokeWidthChange={setStrokeWidth}
+        onFontSizeChange={setFontSize}
       />
       <EditorCanvas
         imagePath={editingItem.currentPath}
@@ -132,6 +136,7 @@ export default function EditorPage({ onBack }: EditorPageProps) {
         activeTool={activeTool}
         strokeColor={strokeColor}
         strokeWidth={strokeWidth}
+        fontSize={fontSize}
         annotations={annotations}
         onZoomChange={setZoom}
         onPanChange={setPan}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,7 +67,17 @@ export interface ArrowAnnotation {
   strokeWidth: number;
 }
 
-export type EditorAnnotation = ArrowAnnotation;
+export interface TextAnnotation {
+  id: string;
+  type: 'text';
+  x: number;
+  y: number;
+  text: string;
+  fontSize: number;
+  strokeColor: string;
+}
+
+export type EditorAnnotation = ArrowAnnotation | TextAnnotation;
 
 export interface EditorState {
   activeTool: EditorTool;


### PR DESCRIPTION
## Summary

Closes #97

- Add text annotation type and inline text input on canvas click (text tool)
- Add font size selector (12/16/24/32/48px) in toolbar when text tool is active
- Render text annotations as SVG `<text>` elements on the canvas
- Add `imageproc` + `ab_glyph` crates for backend text rendering
- Draw text annotations on saved images using system fonts (Arial, Segoe UI)

## Acceptance Criteria

- [x] テキストを追加できる
- [x] 文字サイズ変更ができる
- [x] 保存結果に反映される