### PR TITLE
feat: 四角形ツールを実装する

### DIFF
--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -20,6 +20,8 @@ enum Annotation {
     Arrow(ArrowAnnotation),
     #[serde(rename = "text")]
     Text(TextAnnotation),
+    #[serde(rename = "rectangle")]
+    Rectangle(RectangleAnnotation),
 }
 
 #[derive(Deserialize)]
@@ -41,6 +43,17 @@ struct TextAnnotation {
     text: String,
     font_size: f64,
     stroke_color: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RectangleAnnotation {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    stroke_color: String,
+    stroke_width: u32,
 }
 
 struct Triangle {
@@ -89,6 +102,7 @@ impl EditorService for DefaultEditorService {
                 Annotation::Text(text) => {
                     draw_text_annotation(&mut rgba, text, font_data.as_deref())
                 }
+                Annotation::Rectangle(rect) => draw_rectangle(&mut rgba, rect),
             }
         }
 
@@ -197,6 +211,20 @@ fn draw_arrow(rgba: &mut RgbaImage, arrow: &ArrowAnnotation) {
     let angle = (arrow.end_y - arrow.start_y).atan2(arrow.end_x - arrow.start_x);
     let head_length = f64::from(width) * 4.0;
     draw_arrowhead(rgba, arrow.end_x, arrow.end_y, angle, head_length, color);
+}
+
+fn draw_rectangle(rgba: &mut RgbaImage, rect: &RectangleAnnotation) {
+    let color = parse_color(&rect.stroke_color);
+    let width = rect.stroke_width.max(1);
+    let x0 = rect.x;
+    let y0 = rect.y;
+    let x1 = rect.x + rect.width;
+    let y1 = rect.y + rect.height;
+
+    draw_thick_line(rgba, x0, y0, x1, y0, color, width);
+    draw_thick_line(rgba, x1, y0, x1, y1, color, width);
+    draw_thick_line(rgba, x1, y1, x0, y1, color, width);
+    draw_thick_line(rgba, x0, y1, x0, y0, color, width);
 }
 
 fn draw_thick_line(

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -341,6 +341,7 @@ export function EditorCanvas({
                     height={ann.height}
                     stroke={ann.strokeColor}
                     strokeWidth={ann.strokeWidth}
+                    strokeLinejoin="round"
                     fill="none"
                   />
                 );
@@ -378,6 +379,7 @@ export function EditorCanvas({
                 height={Math.abs(drawing.endY - drawing.startY)}
                 stroke={strokeColor}
                 strokeWidth={strokeWidth}
+                strokeLinejoin="round"
                 fill="none"
               />
             )}

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -146,7 +146,7 @@ export function EditorCanvas({
         setPanStart({ x: e.clientX - panX, y: e.clientY - panY });
         return;
       }
-      if (e.button === 0 && activeTool === 'arrow') {
+      if (e.button === 0 && (activeTool === 'arrow' || activeTool === 'rectangle')) {
         const coords = getImageCoords(e);
         if (coords) {
           setDrawing({
@@ -192,21 +192,36 @@ export function EditorCanvas({
       const dx = drawing.endX - drawing.startX;
       const dy = drawing.endY - drawing.startY;
       if (Math.sqrt(dx * dx + dy * dy) > 5) {
-        onAddAnnotation({
-          id: generateId(),
-          type: 'arrow',
-          startX: drawing.startX,
-          startY: drawing.startY,
-          endX: drawing.endX,
-          endY: drawing.endY,
-          strokeColor,
-          strokeWidth,
-        });
+        if (activeTool === 'arrow') {
+          onAddAnnotation({
+            id: generateId(),
+            type: 'arrow',
+            startX: drawing.startX,
+            startY: drawing.startY,
+            endX: drawing.endX,
+            endY: drawing.endY,
+            strokeColor,
+            strokeWidth,
+          });
+        } else if (activeTool === 'rectangle') {
+          const x = Math.min(drawing.startX, drawing.endX);
+          const y = Math.min(drawing.startY, drawing.endY);
+          onAddAnnotation({
+            id: generateId(),
+            type: 'rectangle',
+            x,
+            y,
+            width: Math.abs(dx),
+            height: Math.abs(dy),
+            strokeColor,
+            strokeWidth,
+          });
+        }
       }
       setDrawing(null);
     }
     setIsPanning(false);
-  }, [drawing, strokeColor, strokeWidth, onAddAnnotation]);
+  }, [drawing, activeTool, strokeColor, strokeWidth, onAddAnnotation]);
 
   const handleTextKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -221,7 +236,7 @@ export function EditorCanvas({
 
   const cursor = isPanning
     ? 'grabbing'
-    : activeTool === 'arrow'
+    : activeTool === 'arrow' || activeTool === 'rectangle'
       ? 'crosshair'
       : activeTool === 'text'
         ? 'text'
@@ -316,9 +331,23 @@ export function EditorCanvas({
                   </text>
                 );
               }
+              if (ann.type === 'rectangle') {
+                return (
+                  <rect
+                    key={ann.id}
+                    x={ann.x}
+                    y={ann.y}
+                    width={ann.width}
+                    height={ann.height}
+                    stroke={ann.strokeColor}
+                    strokeWidth={ann.strokeWidth}
+                    fill="none"
+                  />
+                );
+              }
               return null;
             })}
-            {drawing && (
+            {drawing && activeTool === 'arrow' && (
               <g>
                 <line
                   x1={drawing.startX}
@@ -340,6 +369,17 @@ export function EditorCanvas({
                   fill={strokeColor}
                 />
               </g>
+            )}
+            {drawing && activeTool === 'rectangle' && (
+              <rect
+                x={Math.min(drawing.startX, drawing.endX)}
+                y={Math.min(drawing.startY, drawing.endY)}
+                width={Math.abs(drawing.endX - drawing.startX)}
+                height={Math.abs(drawing.endY - drawing.startY)}
+                stroke={strokeColor}
+                strokeWidth={strokeWidth}
+                fill="none"
+              />
             )}
           </svg>
         )}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,7 +77,18 @@ export interface TextAnnotation {
   strokeColor: string;
 }
 
-export type EditorAnnotation = ArrowAnnotation | TextAnnotation;
+export interface RectangleAnnotation {
+  id: string;
+  type: 'rectangle';
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  strokeColor: string;
+  strokeWidth: number;
+}
+
+export type EditorAnnotation = ArrowAnnotation | TextAnnotation | RectangleAnnotation;
 
 export interface EditorState {
   activeTool: EditorTool;


### PR DESCRIPTION
## Summary

Closes #98

四角形（Rectangle）描画ツールをフルスタックで実装しました。

- **TypeScript**: `RectangleAnnotation` インターフェースを追加し、`EditorAnnotation` ユニオンに統合
- **React (EditorCanvas)**: マウスハンドラー、SVGプレビュー、確定済みアノテーションの描画を追加
- **Rust (editor.rs)**: `RectangleAnnotation` 構造体、`draw_rectangle` 関数（4辺を太線で描画）を追加
- 輪郭色（strokeColor）と線幅（strokeWidth）の設定に対応

## Test Plan

- [x] `cargo test` — 61 tests passed
- [x] `cargo clippy` — no warnings
- [x] TypeScript type check (`tsc --noEmit`) — passed
- [x] ESLint — passed
- [x] Prettier — formatted