### PR TITLE
feat: implement crop/trim tool for image editor

### DIFF
--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -24,9 +24,11 @@ enum Annotation {
     Rectangle(RectangleAnnotation),
     #[serde(rename = "mosaic")]
     Mosaic(MosaicAnnotation),
+    #[serde(rename = "crop")]
+    Crop(CropAnnotation),
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct ArrowAnnotation {
     start_x: f64,
@@ -37,7 +39,7 @@ struct ArrowAnnotation {
     stroke_width: u32,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct TextAnnotation {
     x: f64,
@@ -47,7 +49,7 @@ struct TextAnnotation {
     stroke_color: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct RectangleAnnotation {
     x: f64,
@@ -58,7 +60,7 @@ struct RectangleAnnotation {
     stroke_width: u32,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct MosaicAnnotation {
     x: f64,
@@ -66,6 +68,15 @@ struct MosaicAnnotation {
     width: f64,
     height: f64,
     strength: u32,
+}
+
+#[derive(Deserialize, Copy, Clone)]
+#[serde(rename_all = "camelCase")]
+struct CropAnnotation {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
 }
 
 struct Triangle {
@@ -108,14 +119,56 @@ impl EditorService for DefaultEditorService {
 
         let mut rgba = img.to_rgba8();
         let font_data = load_system_font();
+
+        let crop_region = edit.annotations.iter().find_map(|a| match a {
+            Annotation::Crop(c) => Some(*c),
+            _ => None,
+        });
+
+        if let Some(crop) = crop_region {
+            rgba = apply_crop(&mut rgba, &crop);
+        }
+
+        let offset_x = crop_region.map_or(0.0, |c| c.x);
+        let offset_y = crop_region.map_or(0.0, |c| c.y);
+
         for annotation in &edit.annotations {
             match annotation {
-                Annotation::Arrow(arrow) => draw_arrow(&mut rgba, arrow),
-                Annotation::Text(text) => {
-                    draw_text_annotation(&mut rgba, text, font_data.as_deref())
+                Annotation::Arrow(arrow) => {
+                    let adjusted = ArrowAnnotation {
+                        start_x: arrow.start_x - offset_x,
+                        start_y: arrow.start_y - offset_y,
+                        end_x: arrow.end_x - offset_x,
+                        end_y: arrow.end_y - offset_y,
+                        ..arrow.clone()
+                    };
+                    draw_arrow(&mut rgba, &adjusted);
                 }
-                Annotation::Rectangle(rect) => draw_rectangle(&mut rgba, rect),
-                Annotation::Mosaic(mosaic) => draw_mosaic(&mut rgba, mosaic),
+                Annotation::Text(text) => {
+                    let adjusted = TextAnnotation {
+                        x: text.x - offset_x,
+                        y: text.y - offset_y,
+                        ..text.clone()
+                    };
+                    draw_text_annotation(&mut rgba, &adjusted, font_data.as_deref());
+                }
+                Annotation::Rectangle(rect) => {
+                    let adjusted = RectangleAnnotation {
+                        x: rect.x - offset_x,
+                        y: rect.y - offset_y,
+                        ..rect.clone()
+                    };
+                    draw_rectangle(&mut rgba, &adjusted);
+                }
+                Annotation::Mosaic(mosaic) => {
+                    let adjusted = MosaicAnnotation {
+                        x: mosaic.x - offset_x,
+                        y: mosaic.y - offset_y,
+                        ..mosaic.clone()
+                    };
+                    draw_mosaic(&mut rgba, &adjusted);
+                }
+                Annotation::Crop(_) => {}
             }
         }
 
@@ -142,6 +195,27 @@ fn parse_color(color: &str) -> Rgba<u8> {
     let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
     let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
     Rgba([r, g, b, 255])
+}
+
+fn apply_crop(rgba: &mut RgbaImage, crop: &CropAnnotation) -> RgbaImage {
+    let img_w = rgba.width();
+    let img_h = rgba.height();
+
+    let x0 = crop.x.max(0.0).round() as u32;
+    let y0 = crop.y.max(0.0).round() as u32;
+    let x1 = (crop.x + crop.width).min(f64::from(img_w)).round() as u32;
+    let y1 = (crop.y + crop.height).min(f64::from(img_h)).round() as u32;
+
+    let crop_w = x1.saturating_sub(x0);
+    let crop_h = y1.saturating_sub(y0);
+
+    if crop_w == 0 || crop_h == 0 {
+        return std::mem::take(rgba);
+    }
+
+    let dyn_img = image::DynamicImage::ImageRgba8(std::mem::take(rgba));
+    let cropped = dyn_img.crop_imm(x0, y0, crop_w, crop_h);
+    cropped.to_rgba8()
 }
 
 fn load_system_font() -> Option<Vec<u8>> {

--- a/src-tauri/src/services/editor.rs
+++ b/src-tauri/src/services/editor.rs
@@ -129,8 +129,8 @@ impl EditorService for DefaultEditorService {
             rgba = apply_crop(&mut rgba, &crop);
         }
 
-        let offset_x = crop_region.map_or(0.0, |c| c.x);
-        let offset_y = crop_region.map_or(0.0, |c| c.y);
+        let offset_x = crop_region.map_or(0.0, |c| c.x.max(0.0).round());
+        let offset_y = crop_region.map_or(0.0, |c| c.y.max(0.0).round());
 
         for annotation in &edit.annotations {
             match annotation {
@@ -203,8 +203,11 @@ fn apply_crop(rgba: &mut RgbaImage, crop: &CropAnnotation) -> RgbaImage {
 
     let x0 = crop.x.max(0.0).round() as u32;
     let y0 = crop.y.max(0.0).round() as u32;
-    let x1 = (crop.x + crop.width).min(f64::from(img_w)).round() as u32;
-    let y1 = (crop.y + crop.height).min(f64::from(img_h)).round() as u32;
+    let x1 = (crop.x + crop.width).max(0.0).min(f64::from(img_w)).round() as u32;
+    let y1 = (crop.y + crop.height)
+        .max(0.0)
+        .min(f64::from(img_h))
+        .round() as u32;
 
     let crop_w = x1.saturating_sub(x0);
     let crop_h = y1.saturating_sub(y0);

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -408,26 +408,32 @@ export function EditorCanvas({
               if (ann.type === 'crop') {
                 return (
                   <g key={ann.id}>
-                    <rect x={0} y={0} width={imgSize.width} height={ann.y} fill="rgba(0,0,0,0.5)" />
                     <rect
                       x={0}
-                      y={ann.y}
-                      width={ann.x}
-                      height={ann.height}
+                      y={0}
+                      width={imgSize.width}
+                      height={Math.max(0, ann.y)}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={0}
+                      y={Math.max(0, ann.y)}
+                      width={Math.max(0, ann.x)}
+                      height={Math.max(0, ann.height)}
                       fill="rgba(0,0,0,0.5)"
                     />
                     <rect
                       x={ann.x + ann.width}
-                      y={ann.y}
-                      width={imgSize.width - ann.x - ann.width}
-                      height={ann.height}
+                      y={Math.max(0, ann.y)}
+                      width={Math.max(0, imgSize.width - ann.x - ann.width)}
+                      height={Math.max(0, ann.height)}
                       fill="rgba(0,0,0,0.5)"
                     />
                     <rect
                       x={0}
                       y={ann.y + ann.height}
                       width={imgSize.width}
-                      height={imgSize.height - ann.y - ann.height}
+                      height={Math.max(0, imgSize.height - ann.y - ann.height)}
                       fill="rgba(0,0,0,0.5)"
                     />
                     <rect
@@ -510,20 +516,32 @@ export function EditorCanvas({
                 const ch = Math.abs(drawing.endY - drawing.startY);
                 return (
                   <g>
-                    <rect x={0} y={0} width={imgSize.width} height={cy} fill="rgba(0,0,0,0.5)" />
-                    <rect x={0} y={cy} width={cx} height={ch} fill="rgba(0,0,0,0.5)" />
+                    <rect
+                      x={0}
+                      y={0}
+                      width={imgSize.width}
+                      height={Math.max(0, cy)}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={0}
+                      y={Math.max(0, cy)}
+                      width={Math.max(0, cx)}
+                      height={Math.max(0, ch)}
+                      fill="rgba(0,0,0,0.5)"
+                    />
                     <rect
                       x={cx + cw}
-                      y={cy}
-                      width={imgSize.width - cx - cw}
-                      height={ch}
+                      y={Math.max(0, cy)}
+                      width={Math.max(0, imgSize.width - cx - cw)}
+                      height={Math.max(0, ch)}
                       fill="rgba(0,0,0,0.5)"
                     />
                     <rect
                       x={0}
                       y={cy + ch}
                       width={imgSize.width}
-                      height={imgSize.height - cy - ch}
+                      height={Math.max(0, imgSize.height - cy - ch)}
                       fill="rgba(0,0,0,0.5)"
                     />
                     <rect

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { cn } from '@/lib/utils';
-import type { EditorAnnotation, EditorTool } from '@/types';
+import type { CropAnnotation, EditorAnnotation, EditorTool } from '@/types';
 
 interface EditorCanvasProps {
   imagePath: string;
@@ -16,6 +16,7 @@ interface EditorCanvasProps {
   onZoomChange: (zoom: number) => void;
   onPanChange: (x: number, y: number) => void;
   onAddAnnotation: (annotation: EditorAnnotation) => void;
+  onCropAnnotation: (annotation: CropAnnotation) => void;
   className?: string;
 }
 
@@ -64,6 +65,7 @@ export function EditorCanvas({
   onZoomChange,
   onPanChange,
   onAddAnnotation,
+  onCropAnnotation,
   className,
 }: EditorCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -148,7 +150,10 @@ export function EditorCanvas({
       }
       if (
         e.button === 0 &&
-        (activeTool === 'arrow' || activeTool === 'rectangle' || activeTool === 'mosaic')
+        (activeTool === 'arrow' ||
+          activeTool === 'rectangle' ||
+          activeTool === 'mosaic' ||
+          activeTool === 'crop')
       ) {
         const coords = getImageCoords(e);
         if (coords) {
@@ -231,12 +236,23 @@ export function EditorCanvas({
             height: Math.abs(dy),
             strength: 20, // Default strength
           });
+        } else if (activeTool === 'crop') {
+          const x = Math.min(drawing.startX, drawing.endX);
+          const y = Math.min(drawing.startY, drawing.endY);
+          onCropAnnotation({
+            id: generateId(),
+            type: 'crop',
+            x,
+            y,
+            width: Math.abs(dx),
+            height: Math.abs(dy),
+          });
         }
       }
       setDrawing(null);
     }
     setIsPanning(false);
-  }, [drawing, activeTool, strokeColor, strokeWidth, onAddAnnotation]);
+  }, [drawing, activeTool, strokeColor, strokeWidth, onAddAnnotation, onCropAnnotation]);
 
   const handleTextKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -251,7 +267,10 @@ export function EditorCanvas({
 
   const cursor = isPanning
     ? 'grabbing'
-    : activeTool === 'arrow' || activeTool === 'rectangle' || activeTool === 'mosaic'
+    : activeTool === 'arrow' ||
+        activeTool === 'rectangle' ||
+        activeTool === 'mosaic' ||
+        activeTool === 'crop'
       ? 'crosshair'
       : activeTool === 'text'
         ? 'text'
@@ -386,6 +405,53 @@ export function EditorCanvas({
                   </g>
                 );
               }
+              if (ann.type === 'crop') {
+                return (
+                  <g key={ann.id}>
+                    <rect x={0} y={0} width={imgSize.width} height={ann.y} fill="rgba(0,0,0,0.5)" />
+                    <rect
+                      x={0}
+                      y={ann.y}
+                      width={ann.x}
+                      height={ann.height}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={ann.x + ann.width}
+                      y={ann.y}
+                      width={imgSize.width - ann.x - ann.width}
+                      height={ann.height}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={0}
+                      y={ann.y + ann.height}
+                      width={imgSize.width}
+                      height={imgSize.height - ann.y - ann.height}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={ann.x}
+                      y={ann.y}
+                      width={ann.width}
+                      height={ann.height}
+                      fill="none"
+                      stroke="#fff"
+                      strokeWidth="1.5"
+                      strokeDasharray="6 3"
+                    />
+                    <text
+                      x={ann.x + 4}
+                      y={ann.y + 14}
+                      fontSize="10"
+                      fill="#fff"
+                      style={{ pointerEvents: 'none', userSelect: 'none' }}
+                    >
+                      Crop
+                    </text>
+                  </g>
+                );
+              }
               return null;
             })}
             {drawing && activeTool === 'arrow' && (
@@ -435,6 +501,44 @@ export function EditorCanvas({
                 strokeDasharray="4 2"
               />
             )}
+            {drawing &&
+              activeTool === 'crop' &&
+              (() => {
+                const cx = Math.min(drawing.startX, drawing.endX);
+                const cy = Math.min(drawing.startY, drawing.endY);
+                const cw = Math.abs(drawing.endX - drawing.startX);
+                const ch = Math.abs(drawing.endY - drawing.startY);
+                return (
+                  <g>
+                    <rect x={0} y={0} width={imgSize.width} height={cy} fill="rgba(0,0,0,0.5)" />
+                    <rect x={0} y={cy} width={cx} height={ch} fill="rgba(0,0,0,0.5)" />
+                    <rect
+                      x={cx + cw}
+                      y={cy}
+                      width={imgSize.width - cx - cw}
+                      height={ch}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={0}
+                      y={cy + ch}
+                      width={imgSize.width}
+                      height={imgSize.height - cy - ch}
+                      fill="rgba(0,0,0,0.5)"
+                    />
+                    <rect
+                      x={cx}
+                      y={cy}
+                      width={cw}
+                      height={ch}
+                      fill="none"
+                      stroke="#fff"
+                      strokeWidth="1.5"
+                      strokeDasharray="6 3"
+                    />
+                  </g>
+                );
+              })()}
           </svg>
         )}
         {textInput && imgSize.width > 0 && (

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -5,7 +5,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { EditorToolbar } from '@/components/EditorToolbar';
 import { EditorCanvas } from '@/components/EditorCanvas';
 import { invoke } from '@tauri-apps/api/core';
-import type { CommandResult, EditorAnnotation } from '@/types';
+import type { CommandResult, CropAnnotation, EditorAnnotation } from '@/types';
 
 interface EditorPageProps {
   onBack: () => void;
@@ -31,6 +31,7 @@ export default function EditorPage({ onBack }: EditorPageProps) {
   const setStrokeWidth = useEditorStore((s) => s.setStrokeWidth);
   const setFontSize = useEditorStore((s) => s.setFontSize);
   const addAnnotation = useEditorStore((s) => s.addAnnotation);
+  const replaceCropAnnotation = useEditorStore((s) => s.replaceCropAnnotation);
   const resetEditor = useEditorStore((s) => s.resetEditor);
 
   const { saveEdit, undo, redo } = useEditor();
@@ -88,6 +89,13 @@ export default function EditorPage({ onBack }: EditorPageProps) {
     [addAnnotation],
   );
 
+  const handleCropAnnotation = useCallback(
+    (annotation: CropAnnotation) => {
+      replaceCropAnnotation(annotation);
+    },
+    [replaceCropAnnotation],
+  );
+
   if (!editingItem) {
     return (
       <div className="flex h-full w-full items-center justify-center">
@@ -141,6 +149,7 @@ export default function EditorPage({ onBack }: EditorPageProps) {
         onZoomChange={setZoom}
         onPanChange={setPan}
         onAddAnnotation={handleAddAnnotation}
+        onCropAnnotation={handleCropAnnotation}
         className="flex-1"
       />
     </div>

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { EditorAnnotation, EditorTool } from '@/types';
+import type { CropAnnotation, EditorAnnotation, EditorTool } from '@/types';
 
 interface EditorState {
   activeTool: EditorTool;
@@ -31,6 +31,7 @@ interface EditorState {
   setEditingItem: (itemId: string | null) => void;
   resetEditor: () => void;
   addAnnotation: (annotation: EditorAnnotation) => void;
+  replaceCropAnnotation: (annotation: CropAnnotation) => void;
   removeAnnotation: (id: string) => void;
   clearAnnotations: () => void;
   undoAnnotations: () => void;
@@ -74,6 +75,20 @@ export const useEditorStore = create<EditorState>((set) => ({
   addAnnotation: (annotation) =>
     set((state) => {
       const newAnnotations = [...state.annotations, annotation];
+      return {
+        annotationPast: [...state.annotationPast, state.annotations],
+        annotationFuture: [],
+        annotations: newAnnotations,
+        isDirty: true,
+        canUndo: true,
+        canRedo: false,
+      };
+    }),
+
+  replaceCropAnnotation: (annotation) =>
+    set((state) => {
+      const withoutCrop = state.annotations.filter((a) => a.type !== 'crop');
+      const newAnnotations = [...withoutCrop, annotation];
       return {
         annotationPast: [...state.annotationPast, state.annotations],
         annotationFuture: [],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,11 +98,21 @@ export interface MosaicAnnotation {
   strength: number;
 }
 
+export interface CropAnnotation {
+  id: string;
+  type: 'crop';
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export type EditorAnnotation =
   | ArrowAnnotation
   | TextAnnotation
   | RectangleAnnotation
-  | MosaicAnnotation;
+  | MosaicAnnotation
+  | CropAnnotation;
 
 export interface EditorState {
   activeTool: EditorTool;


### PR DESCRIPTION
## Summary

Closes #100

- Add `CropAnnotation` type and crop tool interaction in `EditorCanvas.tsx` with visual overlay (dimmed area outside crop region)
- Add `replaceCropAnnotation` to editor store ensuring only one crop annotation exists at a time
- Implement server-side crop processing in `editor.rs` using `crop_imm`, with coordinate offset adjustments for other annotations relative to the cropped region
- Image dimensions are updated after save (thumbnail regenerated)

## Changes

| File | Description |
|---|---|
| `src/types/index.ts` | Add `CropAnnotation` interface and extend `EditorAnnotation` union |
| `src/components/EditorCanvas.tsx` | Add crop drawing interaction, crop preview overlay, and crop annotation rendering |
| `src/stores/editorStore.ts` | Add `replaceCropAnnotation` method for single-crop constraint |
| `src/pages/EditorPage.tsx` | Wire `onCropAnnotation` callback to `EditorCanvas` |
| `src-tauri/src/services/editor.rs` | Add `CropAnnotation` struct, `apply_crop` function, coordinate offset logic for other annotations |

## Test plan

- [x] `cargo test` — 61 tests passed
- [x] `cargo clippy` — no warnings
- [x] `eslint --max-warnings 0` — no errors
- [x] `tsc --noEmit` — no type errors
- [ ] Manual: select crop tool, draw region, save, verify image is trimmed