### PR TITLE
feat(editor): implement undo/redo with keyboard shortcuts

### DIFF
--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -45,6 +45,27 @@ export default function EditorPage({ onBack }: EditorPageProps) {
     };
   }, [resetEditor]);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        if (e.key === 'z' && !e.shiftKey) {
+          e.preventDefault();
+          undo();
+        } else if (e.key === 'z' && e.shiftKey) {
+          e.preventDefault();
+          redo();
+        } else if (e.key === 'y') {
+          e.preventDefault();
+          redo();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [undo, redo]);
+
   const handleZoomIn = useCallback(() => {
     setZoom(zoom + 0.25);
   }, [zoom, setZoom]);

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -47,14 +47,16 @@ export default function EditorPage({ onBack }: EditorPageProps) {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
       if (e.ctrlKey || e.metaKey) {
-        if (e.key === 'z' && !e.shiftKey) {
+        const key = e.key.toLowerCase();
+        if (key === 'z' && !e.shiftKey) {
           e.preventDefault();
           undo();
-        } else if (e.key === 'z' && e.shiftKey) {
-          e.preventDefault();
-          redo();
-        } else if (e.key === 'y') {
+        } else if ((key === 'z' && e.shiftKey) || key === 'y') {
           e.preventDefault();
           redo();
         }


### PR DESCRIPTION
## Summary

- Add keyboard shortcuts for undo (`Ctrl+Z`) and redo (`Ctrl+Shift+Z` / `Ctrl+Y`) in the editor page
- Complements the existing undo/redo toolbar buttons and store infrastructure

## Context

The undo/redo state management (past/future stacks) and toolbar UI were already implemented. This PR adds the missing keyboard shortcut handling so users can undo/redo with standard keyboard combinations.

Closes #101