### PR TITLE
fix: Webフォントの読み込みでPendingとなる問題を修正

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';
 


### PR DESCRIPTION
## Summary

- Google Fonts (`fonts.googleapis.com`) からの Noto Sans JP の `@import` を削除しました
- Noto Sans JP は Windows 11 にデフォルトでインストールされているため、Webフォントの読み込みは不要です
- `font-family` の定義はそのまま維持しており、ローカルにインストールされた Noto Sans JP が使用されます

## 関連Issue

Closes #136

## テスト結果

- `cargo test`: 61 passed, 0 failed
- `cargo clippy`: エラーなし
- lint-staged (prettier, TypeScript, clippy): 全て通過