### PR TITLE
feat: asset protocol有効化、サムネイルエラーハンドリング改善、エラーコピー機能追加

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+tauri = { version = "2", features = ["tray-icon", "protocol-asset"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/models/workspace_item.rs
+++ b/src-tauri/src/models/workspace_item.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Workspace item entity
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WorkspaceItem {
     pub id: String,
     #[serde(rename = "type")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,14 @@
   },
   "app": {
     "withGlobalTauri": false,
+    "security": {
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": ["$PICTURES/**", "$HOME/**", "$APPDATA/**", "$TEMP/**"]
+        }
+      }
+    },
     "windows": [
       {
         "title": "AmeCapture",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": ["$PICTURES/**", "$HOME/**", "$APPDATA/**", "$TEMP/**"]
+          "allow": ["$PICTURES/**", "$APPDATA/**", "$TEMP/**"]
         }
       }
     },

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -23,7 +23,7 @@ function DetailThumbnail({ item }: { item: WorkspaceItem }) {
   // item が変更されたらエラー状態をリセット
   useEffect(() => {
     setImgError(false);
-  }, [item.id]);
+  }, [item.id, item.thumbnailPath]);
 
   if (imgError || !item.thumbnailPath) {
     return (

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -17,6 +17,44 @@ interface DetailPanelProps {
   onOpenEditor: () => void;
 }
 
+function DetailThumbnail({ item }: { item: WorkspaceItem }) {
+  const [imgError, setImgError] = useState(false);
+
+  // item が変更されたらエラー状態をリセット
+  useEffect(() => {
+    setImgError(false);
+  }, [item.id]);
+
+  if (imgError || !item.thumbnailPath) {
+    return (
+      <div className="aspect-video rounded-md bg-muted flex items-center justify-center">
+        <span className="text-xs text-muted-foreground">プレビューなし</span>
+      </div>
+    );
+  }
+
+  const src = convertFileSrc(item.thumbnailPath);
+
+  return (
+    <div className="aspect-video rounded-md bg-muted overflow-hidden">
+      <img
+        src={src}
+        alt={item.title}
+        className="w-full h-full object-cover"
+        onError={(e) => {
+          console.warn(`Detail thumbnail load failed`);
+          console.debug(`  item.id: ${item.id}`);
+          console.debug(`  item.title: ${item.title}`);
+          console.debug(`  thumbnailPath: ${item.thumbnailPath}`);
+          console.debug(`  converted src: ${src}`);
+          console.debug(`  event type: ${e.type}`);
+          setImgError(true);
+        }}
+      />
+    </div>
+  );
+}
+
 export function DetailPanel({
   item,
   onClose,
@@ -102,19 +140,7 @@ export function DetailPanel({
       </div>
 
       {/* Preview */}
-      <div className="aspect-video rounded-md bg-muted overflow-hidden">
-        {item.thumbnailPath ? (
-          <img
-            src={convertFileSrc(item.thumbnailPath)}
-            alt={item.title}
-            className="w-full h-full object-cover"
-          />
-        ) : (
-          <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
-            プレビューなし
-          </div>
-        )}
-      </div>
+      <DetailThumbnail item={item} />
 
       {/* Info */}
       <div className="space-y-2 text-sm">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -9,12 +9,13 @@ interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
   errorInfo: ErrorInfo | null;
+  copied: boolean;
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false, error: null, errorInfo: null };
+    this.state = { hasError: false, error: null, errorInfo: null, copied: false };
   }
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
@@ -22,7 +23,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // コンソール＆ログファイルに詳細なエラー情報を出力
     logger.error('=== ErrorBoundary: React rendering error caught ===');
     logger.error('Error:', error);
     logger.error('Error message:', error.message);
@@ -32,6 +32,26 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     this.setState({ errorInfo });
   }
+
+  private handleCopy = () => {
+    const { error, errorInfo } = this.state;
+    const lines: string[] = [
+      '⚠️ アプリケーションエラーが発生しました',
+      '',
+      '【エラーメッセージ】',
+      error?.toString() ?? '',
+      '',
+      '【エラースタックトレース】',
+      error?.stack ?? '',
+      '',
+      '【コンポーネントスタック】',
+      errorInfo?.componentStack ?? '',
+    ];
+    navigator.clipboard.writeText(lines.join('\n')).then(() => {
+      this.setState({ copied: true });
+      setTimeout(() => this.setState({ copied: false }), 2000);
+    });
+  };
 
   render() {
     if (this.state.hasError) {
@@ -55,6 +75,23 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           <h2 style={{ color: '#dc2626', marginTop: 0 }}>
             ⚠️ アプリケーションエラーが発生しました
           </h2>
+
+          <button
+            type="button"
+            onClick={this.handleCopy}
+            style={{
+              marginBottom: '16px',
+              padding: '6px 16px',
+              fontSize: '13px',
+              cursor: 'pointer',
+              border: '1px solid #d1d5db',
+              borderRadius: '4px',
+              backgroundColor: this.state.copied ? '#d1fae5' : '#fff',
+              color: this.state.copied ? '#065f46' : '#374151',
+            }}
+          >
+            {this.state.copied ? '✅ コピーしました' : '📋 エラー情報をコピー'}
+          </button>
 
           <details open style={{ marginBottom: '16px' }}>
             <summary style={{ cursor: 'pointer', fontWeight: 'bold', marginBottom: '8px' }}>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -33,6 +33,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     this.setState({ errorInfo });
   }
 
+  private timerId: ReturnType<typeof setTimeout> | null = null;
+
+  componentWillUnmount() {
+    if (this.timerId !== null) {
+      clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+  }
+
   private handleCopy = () => {
     const { error, errorInfo } = this.state;
     const lines: string[] = [
@@ -47,10 +56,18 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       '【コンポーネントスタック】',
       errorInfo?.componentStack ?? '',
     ];
-    navigator.clipboard.writeText(lines.join('\n')).then(() => {
-      this.setState({ copied: true });
-      setTimeout(() => this.setState({ copied: false }), 2000);
-    });
+    navigator.clipboard.writeText(lines.join('\n')).then(
+      () => {
+        this.setState({ copied: true });
+        this.timerId = setTimeout(() => {
+          this.timerId = null;
+          this.setState({ copied: false });
+        }, 2000);
+      },
+      (err) => {
+        logger.error('Failed to copy error info to clipboard:', err);
+      },
+    );
   };
 
   render() {

--- a/src/components/ThumbnailGrid.tsx
+++ b/src/components/ThumbnailGrid.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import type { WorkspaceItem } from '@/types';
 import { Star, StarOff, Trash2, ImageIcon, Film } from 'lucide-react';
@@ -17,6 +17,10 @@ interface ThumbnailGridProps {
 
 function ThumbnailImage({ item }: { item: WorkspaceItem }) {
   const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [item.id, item.thumbnailPath]);
 
   if (imgError || !item.thumbnailPath) {
     return (

--- a/src/components/ThumbnailGrid.tsx
+++ b/src/components/ThumbnailGrid.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import type { WorkspaceItem } from '@/types';
 import { Star, StarOff, Trash2, ImageIcon, Film } from 'lucide-react';
@@ -12,6 +13,39 @@ interface ThumbnailGridProps {
   onToggleFavorite: (id: string, isFavorite: boolean) => void;
   onDelete: (id: string) => void;
   onOpenEditor: () => void;
+}
+
+function ThumbnailImage({ item }: { item: WorkspaceItem }) {
+  const [imgError, setImgError] = useState(false);
+
+  if (imgError || !item.thumbnailPath) {
+    return (
+      <div className="flex flex-col items-center gap-1 text-muted-foreground">
+        {item.type === 'video' ? <Film className="w-8 h-8" /> : <ImageIcon className="w-8 h-8" />}
+        <span className="text-xs">No preview</span>
+      </div>
+    );
+  }
+
+  const src = convertFileSrc(item.thumbnailPath);
+
+  return (
+    <img
+      src={src}
+      alt={item.title}
+      className="w-full h-full object-cover"
+      loading="lazy"
+      onError={(e) => {
+        console.warn(`Thumbnail load failed`);
+        console.debug(`  item.id: ${item.id}`);
+        console.debug(`  item.title: ${item.title}`);
+        console.debug(`  thumbnailPath: ${item.thumbnailPath}`);
+        console.debug(`  converted src: ${src}`);
+        console.debug(`  event type: ${e.type}`);
+        setImgError(true);
+      }}
+    />
+  );
 }
 
 export function ThumbnailGrid({
@@ -58,23 +92,7 @@ export function ThumbnailGrid({
         >
           {/* Thumbnail */}
           <div className="aspect-video bg-muted flex items-center justify-center relative">
-            {item.thumbnailPath ? (
-              <img
-                src={convertFileSrc(item.thumbnailPath)}
-                alt={item.title}
-                className="w-full h-full object-cover"
-                loading="lazy"
-              />
-            ) : (
-              <div className="flex flex-col items-center gap-1 text-muted-foreground">
-                {item.type === 'video' ? (
-                  <Film className="w-8 h-8" />
-                ) : (
-                  <ImageIcon className="w-8 h-8" />
-                )}
-                <span className="text-xs">No preview</span>
-              </div>
-            )}
+            <ThumbnailImage item={item} />
 
             {/* Type badge */}
             <span


### PR DESCRIPTION
## Summary

- Tauri の `protocol-asset` 機能を有効化し、`assetProtocol` スコープを設定（PICTURES/HOME/APPDATA/TEMP）
- `WorkspaceItem` に `serde(rename_all = "camelCase")` を追加し、フロントエンドとの一貫性を向上
- `ThumbnailGrid`・`DetailPanel` のサムネイル表示を独立コンポーネント（`ThumbnailImage` / `DetailThumbnail`）に抽出し、画像読み込み失敗時のフォールバックとデバッグログを追加
- `ErrorBoundary` にエラー情報をクリップボードにコピーするボタンを追加