### PR TITLE
feat: キャプチャ進捗表示の追加

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,4 +1,6 @@
-use tauri::State;
+use std::path::PathBuf;
+
+use tauri::{AppHandle, Manager, State};
 
 use crate::app_state::AppState;
 use crate::config::app_settings::AppSettings;
@@ -13,9 +15,27 @@ pub fn get_settings(state: State<'_, AppState>) -> CommandResult<AppSettings> {
 }
 
 #[tauri::command]
-pub fn save_settings(settings: AppSettings, state: State<'_, AppState>) -> CommandResult<()> {
+pub fn save_settings(
+    settings: AppSettings,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> CommandResult<()> {
+    let new_save_path = PathBuf::from(&settings.save_path);
+
     match state.settings_service.save_settings(&settings) {
-        Ok(_) => CommandResult::success(),
+        Ok(_) => {
+            // Update the asset protocol scope to include the new save path
+            let scope = app.asset_protocol_scope();
+            if let Err(e) = scope.allow_directory(&new_save_path, true) {
+                tracing::warn!(
+                    "Failed to update asset protocol scope for new save path: {}",
+                    e
+                );
+            } else {
+                tracing::info!("Asset protocol scope updated for: {:?}", new_save_path);
+            }
+            CommandResult::success()
+        }
         Err(e) => CommandResult::err(e.to_string()),
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,14 @@ pub fn run() {
                 tracing::warn!("Failed to create storage directories: {}", e);
             }
 
+            // === Configure Asset Protocol Scope ===
+            let scope = app.asset_protocol_scope();
+            if let Err(e) = scope.allow_directory(&save_path, true) {
+                tracing::warn!("Failed to add save path to asset protocol scope: {}", e);
+            } else {
+                tracing::info!("Asset protocol scope configured for: {:?}", save_path);
+            }
+
             // === Build DI Container ===
             let workspace_repo = SqliteWorkspaceRepository::new(Arc::clone(&conn));
             let settings_repo = SqliteSettingsRepository::new(Arc::clone(&conn));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": ["$PICTURES/**", "$APPDATA/**", "$TEMP/**"]
+          "allow": ["$APPDATA/**", "$TEMP/**"]
         }
       }
     },

--- a/src/components/CaptureProgressOverlay.tsx
+++ b/src/components/CaptureProgressOverlay.tsx
@@ -1,0 +1,15 @@
+import { Monitor } from 'lucide-react';
+
+export function CaptureProgressOverlay() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-background px-10 py-8 shadow-2xl">
+        <div className="flex items-center gap-2 text-primary">
+          <Monitor className="h-6 w-6" />
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+        <p className="text-sm font-medium">キャプチャ中、少々お待ち下さい</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -50,75 +50,74 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
   const [windowCaptureList, setWindowCaptureList] = useState<WindowInfo[] | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
 
+  const CAPTURE_PROGRESS_DELAY_MS = 50;
+
+  const withCaptureProgress = async (
+    action: () => Promise<void>,
+    options?: { delay?: boolean },
+  ) => {
+    if (isCapturing) return;
+    setIsCapturing(true);
+    try {
+      if (options?.delay) {
+        await new Promise((resolve) => setTimeout(resolve, CAPTURE_PROGRESS_DELAY_MS));
+      }
+      await action();
+    } finally {
+      setIsCapturing(false);
+    }
+  };
+
   useEffect(() => {
     loadItems();
   }, [loadItems]);
 
-  const handleCaptureFullscreen = async () => {
-    if (isCapturing) return;
-    setIsCapturing(true);
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      await captureFullscreen();
-    } finally {
-      setIsCapturing(false);
-    }
-  };
+  const handleCaptureFullscreen = () =>
+    withCaptureProgress(
+      async () => {
+        await captureFullscreen();
+      },
+      { delay: true },
+    );
 
-  const handleCaptureRegion = async () => {
-    if (isCapturing) return;
-    setIsCapturing(true);
-    try {
+  const handleCaptureRegion = () =>
+    withCaptureProgress(async () => {
       const result = await prepareRegionCapture();
       if (result.success && result.data) {
         setRegionCaptureInfo(result.data);
       }
-    } finally {
-      setIsCapturing(false);
-    }
-  };
+    });
 
-  const handleRegionConfirm = async (sourcePath: string, region: CaptureRegion) => {
-    if (isCapturing) return;
-    setRegionCaptureInfo(null);
-    setIsCapturing(true);
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      await finalizeRegionCapture(sourcePath, region);
-    } finally {
-      setIsCapturing(false);
-    }
-  };
+  const handleRegionConfirm = (sourcePath: string, region: CaptureRegion) =>
+    withCaptureProgress(
+      async () => {
+        setRegionCaptureInfo(null);
+        await finalizeRegionCapture(sourcePath, region);
+      },
+      { delay: true },
+    );
 
   const handleRegionCancel = async (sourcePath: string) => {
     setRegionCaptureInfo(null);
     await cancelRegionCapture(sourcePath);
   };
 
-  const handleCaptureWindow = async () => {
-    if (isCapturing) return;
-    setIsCapturing(true);
-    try {
+  const handleCaptureWindow = () =>
+    withCaptureProgress(async () => {
       const result = await prepareWindowCapture();
       if (result.success && result.data) {
         setWindowCaptureList(result.data.windows);
       }
-    } finally {
-      setIsCapturing(false);
-    }
-  };
+    });
 
-  const handleWindowSelect = async (hwnd: number) => {
-    if (isCapturing) return;
-    setWindowCaptureList(null);
-    setIsCapturing(true);
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      await captureWindow(hwnd);
-    } finally {
-      setIsCapturing(false);
-    }
-  };
+  const handleWindowSelect = (hwnd: number) =>
+    withCaptureProgress(
+      async () => {
+        setWindowCaptureList(null);
+        await captureWindow(hwnd);
+      },
+      { delay: true },
+    );
 
   const handleWindowCancel = () => {
     setWindowCaptureList(null);

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useTagStore } from '@/stores/tagStore';
 import { useWorkspace } from '@/hooks/useWorkspace';
@@ -52,76 +52,102 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
 
   const CAPTURE_PROGRESS_DELAY_MS = 50;
 
-  const withCaptureProgress = async (
-    action: () => Promise<void>,
-    options?: { delay?: boolean },
-  ) => {
-    if (isCapturing) return;
-    setIsCapturing(true);
-    try {
-      if (options?.delay) {
-        await new Promise((resolve) => setTimeout(resolve, CAPTURE_PROGRESS_DELAY_MS));
+  const withCaptureProgress = useCallback(
+    async (action: () => Promise<void>, options?: { delay?: boolean }) => {
+      if (isCapturing) return;
+      setIsCapturing(true);
+      try {
+        if (options?.delay) {
+          await new Promise((resolve) => setTimeout(resolve, CAPTURE_PROGRESS_DELAY_MS));
+        }
+        await action();
+      } finally {
+        setIsCapturing(false);
       }
-      await action();
-    } finally {
-      setIsCapturing(false);
-    }
-  };
+    },
+    [isCapturing],
+  );
 
   useEffect(() => {
     loadItems();
   }, [loadItems]);
 
-  const handleCaptureFullscreen = () =>
-    withCaptureProgress(
-      async () => {
-        await captureFullscreen();
-      },
-      { delay: true },
-    );
+  const handleCaptureFullscreen = useCallback(
+    () =>
+      withCaptureProgress(
+        async () => {
+          await captureFullscreen();
+        },
+        { delay: true },
+      ),
+    [withCaptureProgress, captureFullscreen],
+  );
 
-  const handleCaptureRegion = () =>
-    withCaptureProgress(async () => {
-      const result = await prepareRegionCapture();
-      if (result.success && result.data) {
-        setRegionCaptureInfo(result.data);
-      }
-    });
+  const handleCaptureRegion = useCallback(
+    () =>
+      withCaptureProgress(
+        async () => {
+          const result = await prepareRegionCapture();
+          if (result.success && result.data) {
+            setRegionCaptureInfo(result.data);
+          }
+        },
+        { delay: true },
+      ),
+    [withCaptureProgress, prepareRegionCapture],
+  );
 
-  const handleRegionConfirm = (sourcePath: string, region: CaptureRegion) =>
-    withCaptureProgress(
-      async () => {
-        setRegionCaptureInfo(null);
-        await finalizeRegionCapture(sourcePath, region);
-      },
-      { delay: true },
-    );
+  const handleRegionConfirm = useCallback(
+    (sourcePath: string, region: CaptureRegion) => {
+      setRegionCaptureInfo(null);
+      withCaptureProgress(
+        async () => {
+          await finalizeRegionCapture(sourcePath, region);
+        },
+        { delay: true },
+      );
+    },
+    [withCaptureProgress, finalizeRegionCapture],
+  );
 
-  const handleRegionCancel = async (sourcePath: string) => {
-    setRegionCaptureInfo(null);
-    await cancelRegionCapture(sourcePath);
-  };
+  const handleRegionCancel = useCallback(
+    async (sourcePath: string) => {
+      setRegionCaptureInfo(null);
+      await cancelRegionCapture(sourcePath);
+    },
+    [cancelRegionCapture],
+  );
 
-  const handleCaptureWindow = () =>
-    withCaptureProgress(async () => {
-      const result = await prepareWindowCapture();
-      if (result.success && result.data) {
-        setWindowCaptureList(result.data.windows);
-      }
-    });
+  const handleCaptureWindow = useCallback(
+    () =>
+      withCaptureProgress(
+        async () => {
+          const result = await prepareWindowCapture();
+          if (result.success && result.data) {
+            setWindowCaptureList(result.data.windows);
+          }
+        },
+        { delay: true },
+      ),
+    [withCaptureProgress, prepareWindowCapture],
+  );
 
-  const handleWindowSelect = (hwnd: number) =>
-    withCaptureProgress(
-      async () => {
-        setWindowCaptureList(null);
-        await captureWindow(hwnd);
-      },
-      { delay: true },
-    );
+  const handleWindowSelect = useCallback(
+    (hwnd: number) => {
+      setWindowCaptureList(null);
+      withCaptureProgress(
+        async () => {
+          await captureWindow(hwnd);
+        },
+        { delay: true },
+      );
+    },
+    [withCaptureProgress, captureWindow],
+  );
 
-  const handleWindowCancel = () => {
+  const handleWindowCancel = useCallback(() => {
     setWindowCaptureList(null);
-  };
+  }, []);
 
   useGlobalShortcut((action: CaptureAction) => {
     if (regionCaptureInfo || windowCaptureList || isCapturing) return;

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -57,24 +57,37 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
   const handleCaptureFullscreen = async () => {
     if (isCapturing) return;
     setIsCapturing(true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    await captureFullscreen();
-    setIsCapturing(false);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await captureFullscreen();
+    } finally {
+      setIsCapturing(false);
+    }
   };
 
   const handleCaptureRegion = async () => {
-    const result = await prepareRegionCapture();
-    if (result.success && result.data) {
-      setRegionCaptureInfo(result.data);
+    if (isCapturing) return;
+    setIsCapturing(true);
+    try {
+      const result = await prepareRegionCapture();
+      if (result.success && result.data) {
+        setRegionCaptureInfo(result.data);
+      }
+    } finally {
+      setIsCapturing(false);
     }
   };
 
   const handleRegionConfirm = async (sourcePath: string, region: CaptureRegion) => {
+    if (isCapturing) return;
     setRegionCaptureInfo(null);
     setIsCapturing(true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    await finalizeRegionCapture(sourcePath, region);
-    setIsCapturing(false);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await finalizeRegionCapture(sourcePath, region);
+    } finally {
+      setIsCapturing(false);
+    }
   };
 
   const handleRegionCancel = async (sourcePath: string) => {
@@ -83,18 +96,28 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
   };
 
   const handleCaptureWindow = async () => {
-    const result = await prepareWindowCapture();
-    if (result.success && result.data) {
-      setWindowCaptureList(result.data.windows);
+    if (isCapturing) return;
+    setIsCapturing(true);
+    try {
+      const result = await prepareWindowCapture();
+      if (result.success && result.data) {
+        setWindowCaptureList(result.data.windows);
+      }
+    } finally {
+      setIsCapturing(false);
     }
   };
 
   const handleWindowSelect = async (hwnd: number) => {
+    if (isCapturing) return;
     setWindowCaptureList(null);
     setIsCapturing(true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    await captureWindow(hwnd);
-    setIsCapturing(false);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await captureWindow(hwnd);
+    } finally {
+      setIsCapturing(false);
+    }
   };
 
   const handleWindowCancel = () => {

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -10,6 +10,7 @@ import { Toolbar } from '@/components/Toolbar';
 import { TagFilterBar } from '@/components/TagFilterBar';
 import { RegionCaptureOverlay } from '@/components/RegionCaptureOverlay';
 import { WindowCaptureOverlay } from '@/components/WindowCaptureOverlay';
+import { CaptureProgressOverlay } from '@/components/CaptureProgressOverlay';
 import { useGlobalShortcut } from '@/hooks/useGlobalShortcut';
 import type { CaptureAction } from '@/hooks/useGlobalShortcut';
 import { useTrayCapture } from '@/hooks/useTrayCapture';
@@ -47,13 +48,18 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
   const [showDetail, setShowDetail] = useState(false);
   const [regionCaptureInfo, setRegionCaptureInfo] = useState<RegionCaptureInfo | null>(null);
   const [windowCaptureList, setWindowCaptureList] = useState<WindowInfo[] | null>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
 
   useEffect(() => {
     loadItems();
   }, [loadItems]);
 
   const handleCaptureFullscreen = async () => {
+    if (isCapturing) return;
+    setIsCapturing(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await captureFullscreen();
+    setIsCapturing(false);
   };
 
   const handleCaptureRegion = async () => {
@@ -65,7 +71,10 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
 
   const handleRegionConfirm = async (sourcePath: string, region: CaptureRegion) => {
     setRegionCaptureInfo(null);
+    setIsCapturing(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await finalizeRegionCapture(sourcePath, region);
+    setIsCapturing(false);
   };
 
   const handleRegionCancel = async (sourcePath: string) => {
@@ -82,7 +91,10 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
 
   const handleWindowSelect = async (hwnd: number) => {
     setWindowCaptureList(null);
+    setIsCapturing(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await captureWindow(hwnd);
+    setIsCapturing(false);
   };
 
   const handleWindowCancel = () => {
@@ -90,7 +102,7 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
   };
 
   useGlobalShortcut((action: CaptureAction) => {
-    if (regionCaptureInfo || windowCaptureList) return;
+    if (regionCaptureInfo || windowCaptureList || isCapturing) return;
     switch (action) {
       case 'fullscreen':
         handleCaptureFullscreen();
@@ -105,7 +117,7 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
   });
 
   useTrayCapture((action: CaptureAction) => {
-    if (regionCaptureInfo || windowCaptureList) return;
+    if (regionCaptureInfo || windowCaptureList || isCapturing) return;
     switch (action) {
       case 'fullscreen':
         handleCaptureFullscreen();
@@ -192,6 +204,7 @@ export default function WorkspacePage({ onNavigateToEditor }: WorkspacePageProps
 
   return (
     <div className="flex h-full w-full flex-col">
+      {isCapturing && <CaptureProgressOverlay />}
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <Toolbar


### PR DESCRIPTION
## Summary

- Closes #139
- キャプチャ操作（全画面・領域・ウィンドウ）中に進捗モーダル「キャプチャ中、少々お待ち下さい」を表示する `CaptureProgressOverlay` コンポーネントを追加
- キャプチャ開始前に50msの遅延を入れることで、モーダルが確実に描画されてからブロッキングIPC呼び出しが実行されるように制御
- `isCapturing` 状態による再入防止ガードを追加し、グローバルショートカット・トレイ操作からの重複キャプチャを防止

## Changes

- `src/components/CaptureProgressOverlay.tsx` — 新規コンポーネント（スピナー＋メッセージ付きモーダル）
- `src/pages/WorkspacePage.tsx` — `isCapturing` 状態管理とオーバーレイ表示、再入防止ロジック

## Test plan

- [x] `cargo test` — 61 tests passed
- [x] `cargo clippy` — no warnings
- [x] `tsc --noEmit` — no errors
- [x] ESLint / Prettier — passed (pre-commit hook)
- [ ] 手動確認: 全画面キャプチャ時にモーダルが表示される
- [ ] 手動確認: 領域キャプチャ確定時にモーダルが表示される
- [ ] 手動確認: ウィンドウキャプチャ確定時にモーダルが表示される