### PR TITLE
feat: add OpenCode GitHub Actions workflow for issue and PR automation

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+        with:
+          model: zai-coding-plan/glm-5.1


### PR DESCRIPTION
## Summary

- OpenCode と GitHub の連携を行う GitHub Actions ワークフロー (`.github/workflows/opencode.yml`) を追加
- Issue コメントや PR レビューコメントで `/opencode` または `/oc` とメンションすることでトリガーされる
- モデルには `zai-coding-plan/glm-5.1` を使用し、`ZHIPU_API_KEY` シークレットを参照

## Usage

- Issue で `/opencode fix this` のようにコメントすると、OpenCode が自動で対応
- PR で `/oc` を含むコメントで変更依頼やレビューが可能