### PR TITLE
feat: reduce default window size from 1200x800 to 1100x750

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,8 +22,8 @@
     "windows": [
       {
         "title": "AmeCapture",
-        "width": 1200,
-        "height": 800,
+        "width": 1100,
+        "height": 750,
         "resizable": true,
         "fullscreen": false,
         "minWidth": 800,


### PR DESCRIPTION
## Summary

- Reduce default window width from 1200 to 1100 and height from 800 to 750 in src-tauri/tauri.conf.json
- Minimum size constraints (minWidth: 800, minHeight: 600) remain unchanged
- resizable: true is preserved so users can freely resize

Closes #143