### PR TITLE
docs: 既存機能一覧をMVP必須/後追いに分類

### DIFF
--- a/documents/6. 既存機能一覧_MVP必須_後追い分類.md
+++ b/documents/6. 既存機能一覧_MVP必須_後追い分類.md
@@ -1,0 +1,101 @@
+# 既存機能一覧 - MVP必須 / 後追い 分類
+
+## 機能トレーサビリティ表
+
+### キャプチャ機能
+
+| #   | 機能                       | 対応ソース                                                                      | MVP必須  | 備考     |
+| --- | -------------------------- | ------------------------------------------------------------------------------- | -------- | -------- |
+| C1  | 全画面キャプチャ           | `commands/capture.rs` → `capture()`                                             | **必須** | コア機能 |
+| C2  | 範囲キャプチャ             | `commands/capture.rs` → `prepare_region_capture()`, `finalize_region_capture()` | **必須** | コア機能 |
+| C3  | ウィンドウキャプチャ       | `commands/capture.rs` → `prepare_window_capture()`                              | **必須** | コア機能 |
+| C4  | キャプチャ進捗表示         | `components/CaptureProgressOverlay.tsx`                                         | 後追い   | UX改善   |
+| C5  | 範囲選択オーバーレイ       | `components/RegionCaptureOverlay.tsx`                                           | **必須** | C2の一部 |
+| C6  | ウィンドウ選択オーバーレイ | `components/WindowCaptureOverlay.tsx`                                           | **必須** | C3の一部 |
+
+### ワークスペース機能
+
+| #   | 機能                   | 対応ソース                                            | MVP必須  | 備考     |
+| --- | ---------------------- | ----------------------------------------------------- | -------- | -------- |
+| W1  | キャプチャ履歴一覧     | `pages/WorkspacePage.tsx` → `ThumbnailGrid`           | **必須** | コア機能 |
+| W2  | アイテム削除           | `commands/workspace.rs` → `delete_workspace_item()`   | **必須** | コア機能 |
+| W3  | アイテム名変更         | `commands/workspace.rs` → `rename_workspace_item()`   | **必須** | コア機能 |
+| W4  | お気に入り切替         | `commands/workspace.rs` → `toggle_favorite()`         | 後追い   | 優先度低 |
+| W5  | ファイルの場所を開く   | `commands/workspace.rs` → `show_item_in_folder()`     | **必須** | 利便性   |
+| W6  | クリップボードにコピー | `commands/workspace.rs` → `copy_image_to_clipboard()` | **必須** | 利便性   |
+| W7  | サムネイル生成         | `services/thumbnail.rs`                               | **必須** | W1の前提 |
+| W8  | 検索バー               | `components/SearchBar.tsx`                            | 後追い   | UX改善   |
+| W9  | タグフィルター         | `components/TagFilterBar.tsx`                         | 後追い   | W10依存  |
+
+### タグ機能
+
+| #   | 機能               | 対応ソース                              | MVP必須 | 備考     |
+| --- | ------------------ | --------------------------------------- | ------- | -------- |
+| T1  | タグ作成           | `commands/tag.rs` → `create_tag()`      | 後追い  | 優先度低 |
+| T2  | タグ削除           | `commands/tag.rs` → `delete_tag()`      | 後追い  | T1依存   |
+| T3  | アイテムにタグ付与 | `commands/tag.rs` → `add_tag_to_item()` | 後追い  | T1依存   |
+| T4  | タグ入力           | `components/TagInput.tsx`               | 後追い  | T1依存   |
+
+### エディタ機能
+
+| #   | 機能             | 対応ソース                                               | MVP必須  | 備考           |
+| --- | ---------------- | -------------------------------------------------------- | -------- | -------------- |
+| E1  | 画像編集（注釈） | `pages/EditorPage.tsx` → `EditorCanvas`, `EditorToolbar` | **必須** | コア機能       |
+| E2  | 矢印描画         | `services/editor.rs`                                     | **必須** | E1の一部       |
+| E3  | テキスト描画     | `services/editor.rs`                                     | **必須** | E1の一部       |
+| E4  | 矩形描画         | `services/editor.rs`                                     | **必須** | E1の一部       |
+| E5  | モザイク         | `services/editor.rs`                                     | **必須** | E1の一部       |
+| E6  | 切り抜き         | `services/editor.rs`                                     | **必須** | E1の一部       |
+| E7  | 保存（上書き）   | `commands/editor.rs` → `save_edit()`                     | **必須** | E1の一部       |
+| E8  | Undo/Redo        | `commands/editor.rs` → `undo()`, `redo()`                | 後追い   | スタブ実装あり |
+
+### ショートカット・システム機能
+
+| #   | 機能                         | 対応ソース                                  | MVP必須  | 備考                 |
+| --- | ---------------------------- | ------------------------------------------- | -------- | -------------------- |
+| S1  | グローバルホットキー         | `hooks/useGlobalShortcut.ts` + Tauri plugin | **必須** | コア機能             |
+| S2  | システムトレイ               | `lib.rs` → tray menu                        | **必須** | バックグラウンド動作 |
+| S3  | トレイメニューからキャプチャ | `lib.rs` → tray menu items                  | **必須** | S2の一部             |
+
+### 設定機能
+
+| #   | 機能                 | 対応ソース                                 | MVP必須  | 備考                    |
+| --- | -------------------- | ------------------------------------------ | -------- | ----------------------- |
+| P1  | 設定画面             | `pages/SettingsPage.tsx`                   | **必須** | コア機能                |
+| P2  | 保存先パス設定       | `commands/settings.rs` → `save_settings()` | **必須** | P1の一部                |
+| P3  | 画像フォーマット設定 | `config/app_settings.rs`                   | 後追い   | デフォルトPNGで問題なし |
+| P4  | ホットキー設定       | `config/app_settings.rs`                   | 後追い   | デフォルトで動作        |
+
+### ストレージ機能
+
+| #   | 機能                                               | 対応ソース                               | MVP必須  | 備考         |
+| --- | -------------------------------------------------- | ---------------------------------------- | -------- | ------------ |
+| R1  | ファイル保存（originals/edited/thumbnails/videos） | `services/storage.rs` + `storage/mod.rs` | **必須** | コア機能     |
+| R2  | パス解決・サニタイズ                               | `storage/mod.rs`                         | **必須** | セキュリティ |
+
+---
+
+## 集計
+
+| 分類        | 件数 |
+| ----------- | ---- |
+| **MVP必須** | 22   |
+| **後追い**  | 9    |
+| **合計**    | 31   |
+
+## MVP対象機能（実装優先度順）
+
+1. 全画面・範囲・ウィンドウキャプチャ（C1, C2, C3, C5, C6）
+2. ストレージ・サムネイル（R1, R2, W7）
+3. ワークスペース一覧・削除・名変更（W1, W2, W3, W5, W6）
+4. 画像エディタ・注釈（E1〜E7）
+5. グローバルホットキー・システムトレイ（S1, S2, S3）
+6. 設定画面（P1, P2）
+
+## 後追い機能
+
+- お気に入り（W4）, 検索（W8）, タグフィルター（W9）
+- タグ管理（T1〜T4）
+- Undo/Redo（E8）
+- キャプチャ進捗表示（C4）
+- 画像フォーマット・ホットキー設定UI（P3, P4）

--- a/documents/6. 既存機能一覧_MVP必須_後追い分類.md
+++ b/documents/6. 既存機能一覧_MVP必須_後追い分類.md
@@ -15,17 +15,17 @@
 
 ### ワークスペース機能
 
-| #   | 機能                   | 対応ソース                                            | MVP必須  | 備考     |
-| --- | ---------------------- | ----------------------------------------------------- | -------- | -------- |
-| W1  | キャプチャ履歴一覧     | `pages/WorkspacePage.tsx` → `ThumbnailGrid`           | **必須** | コア機能 |
-| W2  | アイテム削除           | `commands/workspace.rs` → `delete_workspace_item()`   | **必須** | コア機能 |
-| W3  | アイテム名変更         | `commands/workspace.rs` → `rename_workspace_item()`   | **必須** | コア機能 |
-| W4  | お気に入り切替         | `commands/workspace.rs` → `toggle_favorite()`         | 後追い   | 優先度低 |
-| W5  | ファイルの場所を開く   | `commands/workspace.rs` → `show_item_in_folder()`     | **必須** | 利便性   |
-| W6  | クリップボードにコピー | `commands/workspace.rs` → `copy_image_to_clipboard()` | **必須** | 利便性   |
-| W7  | サムネイル生成         | `services/thumbnail.rs`                               | **必須** | W1の前提 |
-| W8  | 検索バー               | `components/SearchBar.tsx`                            | 後追い   | UX改善   |
-| W9  | タグフィルター         | `components/TagFilterBar.tsx`                         | 後追い   | W10依存  |
+| #   | 機能                   | 対応ソース                                            | MVP必須  | 備考       |
+| --- | ---------------------- | ----------------------------------------------------- | -------- | ---------- |
+| W1  | キャプチャ履歴一覧     | `pages/WorkspacePage.tsx` → `ThumbnailGrid`           | **必須** | コア機能   |
+| W2  | アイテム削除           | `commands/workspace.rs` → `delete_workspace_item()`   | **必須** | コア機能   |
+| W3  | アイテム名変更         | `commands/workspace.rs` → `rename_workspace_item()`   | **必須** | コア機能   |
+| W4  | お気に入り切替         | `commands/workspace.rs` → `toggle_favorite()`         | 後追い   | 優先度低   |
+| W5  | ファイルの場所を開く   | `commands/workspace.rs` → `show_item_in_folder()`     | **必須** | 利便性     |
+| W6  | クリップボードにコピー | `commands/workspace.rs` → `copy_image_to_clipboard()` | **必須** | 利便性     |
+| W7  | サムネイル生成         | `services/thumbnail.rs`                               | **必須** | W1の前提   |
+| W8  | 検索バー               | `components/SearchBar.tsx`                            | 後追い   | UX改善     |
+| W9  | タグフィルター         | `components/TagFilterBar.tsx`                         | 後追い   | T1〜T4依存 |
 
 ### タグ機能
 
@@ -79,9 +79,9 @@
 
 | 分類        | 件数 |
 | ----------- | ---- |
-| **MVP必須** | 22   |
-| **後追い**  | 9    |
-| **合計**    | 31   |
+| **MVP必須** | 25   |
+| **後追い**  | 11   |
+| **合計**    | 36   |
 
 ## MVP対象機能（実装優先度順）
 


### PR DESCRIPTION
## Summary

- 36機能を7カテゴリ（キャプチャ・ワークスペース・タグ・エディタ・ショートカット・設定・ストレージ）に整理
- MVP必須25機能 / 後追い11機能に分類
- 実装優先度順でMVP対象機能を列出

Closes #175