### PR TITLE
docs: UIワイヤーフレームをMAUI向けに再定義

### DIFF
--- a/documents/7. UIワイヤーフレーム_MAUI向け再定義.md
+++ b/documents/7. UIワイヤーフレーム_MAUI向け再定義.md
@@ -43,7 +43,7 @@
 - `Grid` (2行: ヘッダー + コンテンツ)
   - Row 0: `HorizontalStackLayout` (タイトル + SearchBar + 設定ボタン)
   - Row 1: `CollectionView` (GridItemsLayout, Span=4) でサムネイル一覧
-- 各アイテム: `Frame` > `VerticalStackLayout` > `Image` + `Label`(タイトル) + `Label`(日付)
+- 各アイテム: `Border` > `VerticalStackLayout` > `Image` + `Label`(タイトル) + `Label`(日付)
 
 ### EditorPage（エディタ）
 
@@ -114,7 +114,7 @@
 | ------------- | ---------------------------- | ------------------------------------ | ---------------------------------------------- | --------- |
 | WorkspacePage | ItemsSource (CollectionView) | WorkspaceViewModel.WorkspaceItems    | `ObservableCollection<WorkspaceItemViewModel>` | View ← VM |
 | WorkspacePage | SearchText                   | WorkspaceViewModel.SearchText        | `string`                                       | View ↔ VM |
-| WorkspacePage | SelectedTags                 | WorkspaceViewModel.SelectedTags      | `ObservableCollection<Tag>`                    | View ↔ VM |
+| WorkspacePage | SelectedItems                | WorkspaceViewModel.SelectedItems     | `IList`                                        | View ↔ VM |
 | WorkspacePage | DeleteCommand                | WorkspaceViewModel.DeleteCommand     | `ICommand`                                     | View → VM |
 | WorkspacePage | RenameCommand                | WorkspaceViewModel.RenameCommand     | `ICommand`                                     | View → VM |
 | WorkspacePage | OpenEditorCommand            | WorkspaceViewModel.OpenEditorCommand | `ICommand`                                     | View → VM |
@@ -152,16 +152,16 @@ builder.Services.AddTransient<SettingsPage>();
 
 ## 4. 共通コンポーネント（MAUI対応）
 
-| 既存 React コンポーネント | MAUI 対応                                    | 種類                 |
-| ------------------------- | -------------------------------------------- | -------------------- |
-| `ThumbnailGrid`           | `CollectionView` + `GridItemsLayout`         | 標準コントロール     |
-| `SearchBar`               | `SearchBar`                                  | 標準コントロール     |
-| `TagFilterBar`            | `HorizontalStackLayout` + `Button` or `Chip` | カスタム             |
-| `TagInput`                | `Entry` + `HorizontalStackLayout`            | カスタム             |
-| `Toolbar`                 | `HorizontalStackLayout` + `ImageButton`      | カスタム             |
-| `EditorToolbar`           | `HorizontalStackLayout` + `Button`           | カスタム             |
-| `EditorCanvas`            | `GraphicsView` (MAUI Graphics) or SkiaSharp  | カスタム             |
-| `ErrorBoundary`           | `try-catch` + Serilog logging                | コード               |
-| `DetailPanel`             | `ScrollView` + `VerticalStackLayout`         | カスタム             |
-| `RegionCaptureOverlay`    | `Window` + `GraphicsView` (フルスクリーン)   | プラットフォーム固有 |
-| `WindowCaptureOverlay`    | `Window` + リスト                            | プラットフォーム固有 |
+| 既存 React コンポーネント | MAUI 対応                                              | 種類                 |
+| ------------------------- | ------------------------------------------------------ | -------------------- |
+| `ThumbnailGrid`           | `CollectionView` + `GridItemsLayout`                   | 標準コントロール     |
+| `SearchBar`               | `SearchBar`                                            | 標準コントロール     |
+| `TagFilterBar`            | `HorizontalStackLayout` + `Button` or `Chip`           | カスタム             |
+| `TagInput`                | `Entry` + `HorizontalStackLayout`                      | カスタム             |
+| `Toolbar`                 | `HorizontalStackLayout` + `ImageButton`                | カスタム             |
+| `EditorToolbar`           | `HorizontalStackLayout` + `Button`                     | カスタム             |
+| `EditorCanvas`            | `GraphicsView` (MAUI Graphics) or SkiaSharp            | カスタム             |
+| `ErrorBoundary`           | `Global Exception Handler` (AppDomain + TaskScheduler) | コード               |
+| `DetailPanel`             | `ScrollView` + `VerticalStackLayout`                   | カスタム             |
+| `RegionCaptureOverlay`    | `Window` + `GraphicsView` (フルスクリーン)             | プラットフォーム固有 |
+| `WindowCaptureOverlay`    | `Window` + リスト                                      | プラットフォーム固有 |

--- a/documents/7. UIワイヤーフレーム_MAUI向け再定義.md
+++ b/documents/7. UIワイヤーフレーム_MAUI向け再定義.md
@@ -1,0 +1,167 @@
+# UIワイヤーフレーム - MAUI再定義
+
+## 1. 画面一覧
+
+| 画面           | 既存 React          | MAUI View                  | MAUI ViewModel                  |
+| -------------- | ------------------- | -------------------------- | ------------------------------- |
+| ワークスペース | `WorkspacePage.tsx` | `Views/WorkspacePage.xaml` | `ViewModels/WorkspaceViewModel` |
+| エディタ       | `EditorPage.tsx`    | `Views/EditorPage.xaml`    | `ViewModels/EditorViewModel`    |
+| 設定           | `SettingsPage.tsx`  | `Views/SettingsPage.xaml`  | `ViewModels/SettingsViewModel`  |
+
+---
+
+## 2. ワイヤーフレーム
+
+### WorkspacePage（ワークスペース）
+
+```
+┌──────────────────────────────────────────────────┐
+│  AmeCapture          [検索バー]     [設定⚙]       │
+├──────────────────────────────────────────────────┤
+│  [タグフィルターバー: 全て | タグ1 | タグ2 | ...] │
+├──────────────────────────────────────────────────┤
+│  ┌─────┐  ┌─────┐  ┌─────┐  ┌─────┐            │
+│  │ 📷  │  │ 📷  │  │ 📷  │  │ 📷  │            │
+│  │     │  │     │  │     │  │     │            │
+│  │タイトル│  │タイトル│  │タイトル│  │タイトル│            │
+│  │ 日付 │  │ 日付 │  │ 日付 │  │ 日付 │            │
+│  └─────┘  └─────┘  └─────┘  └─────┘            │
+│  ┌─────┐  ┌─────┐  ┌─────┐  ┌─────┐            │
+│  │ 📷  │  │ 📷  │  │ 📷  │  │ 📷  │            │
+│  │     │  │     │  │     │  │     │            │
+│  │タイトル│  │タイトル│  │タイトル│  │タイトル│            │
+│  │ 日付 │  │ 日付 │  │ 日付 │  │ 日付 │            │
+│  └─────┘  └─────┘  └─────┘  └─────┘            │
+│                                                  │
+│          （空の場合："No captures yet"）          │
+└──────────────────────────────────────────────────┘
+```
+
+**MAUI レイアウト構成:**
+
+- `Shell` → ナビゲーション
+- `Grid` (2行: ヘッダー + コンテンツ)
+  - Row 0: `HorizontalStackLayout` (タイトル + SearchBar + 設定ボタン)
+  - Row 1: `CollectionView` (GridItemsLayout, Span=4) でサムネイル一覧
+- 各アイテム: `Frame` > `VerticalStackLayout` > `Image` + `Label`(タイトル) + `Label`(日付)
+
+### EditorPage（エディタ）
+
+```
+┌──────────────────────────────────────────────────┐
+│  ← 戻る    タイトル              [保存] [やり直し] │
+├──────────────────────────────────────────────────┤
+│  ツールバー: [矢印] [テキスト] [矩形] [モザイク]  │
+│             [切り抜き] [Undo] [Redo]              │
+├──────────────────────────────────────────────────┤
+│                                                  │
+│                                                  │
+│              ┌─────────────────┐                 │
+│              │                 │                 │
+│              │    画像編集     │                 │
+│              │    キャンバス   │                 │
+│              │                 │                 │
+│              └─────────────────┘                 │
+│                                                  │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+**MAUI レイアウト構成:**
+
+- `ContentPage` with `Grid` (3行)
+  - Row 0: `HorizontalStackLayout` (戻るボタン + タイトル + 保存/やり直し)
+  - Row 1: `HorizontalStackLayout` (ツールボタン群)
+  - Row 2: `GraphicsView` または `SKCanvasView` (SkiaSharp) で画像キャンバス
+- 描画操作は `GraphicsView` のタッチ/マウスイベントで処理
+
+### SettingsPage（設定）
+
+```
+┌──────────────────────────────────────────────────┐
+│  ← 戻る    設定                                  │
+├──────────────────────────────────────────────────┤
+│                                                  │
+│  保存先パス:  [C:\Pictures\AmeCapture]  [参照]   │
+│                                                  │
+│  画像フォーマット:  [PNG ▼]                       │
+│                                                  │
+│  ホットキー設定:                                  │
+│    全画面キャプチャ:    [Ctrl+Shift+S]            │
+│    範囲キャプチャ:      [Ctrl+Shift+F]            │
+│    ウィンドウキャプチャ: [Ctrl+Shift+W]           │
+│                                                  │
+│                                      [保存]       │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+**MAUI レイアウト構成:**
+
+- `ContentPage` with `ScrollView` > `VerticalStackLayout`
+- 各設定項目: `Grid` (2列: Label + Entry/Picker/Button)
+- 保存先: `Entry` + `Button` (フォルダーピッカー)
+- フォーマット: `Picker`
+- ホットキー: `Entry` (読み取り専用 + キー録音)
+
+---
+
+## 3. MVVM 構成対応表
+
+### View ↔ ViewModel バインディング
+
+| View          | プロパティ/コマンド          | ViewModel                            | 型                                             | 方向      |
+| ------------- | ---------------------------- | ------------------------------------ | ---------------------------------------------- | --------- |
+| WorkspacePage | ItemsSource (CollectionView) | WorkspaceViewModel.WorkspaceItems    | `ObservableCollection<WorkspaceItemViewModel>` | View ← VM |
+| WorkspacePage | SearchText                   | WorkspaceViewModel.SearchText        | `string`                                       | View ↔ VM |
+| WorkspacePage | SelectedTags                 | WorkspaceViewModel.SelectedTags      | `ObservableCollection<Tag>`                    | View ↔ VM |
+| WorkspacePage | DeleteCommand                | WorkspaceViewModel.DeleteCommand     | `ICommand`                                     | View → VM |
+| WorkspacePage | RenameCommand                | WorkspaceViewModel.RenameCommand     | `ICommand`                                     | View → VM |
+| WorkspacePage | OpenEditorCommand            | WorkspaceViewModel.OpenEditorCommand | `ICommand`                                     | View → VM |
+| EditorPage    | CurrentImage                 | EditorViewModel.CurrentImage         | `ImageSource`                                  | View ← VM |
+| EditorPage    | SelectedTool                 | EditorViewModel.SelectedTool         | `EditorTool` (enum)                            | View ↔ VM |
+| EditorPage    | SaveCommand                  | EditorViewModel.SaveCommand          | `ICommand`                                     | View → VM |
+| EditorPage    | UndoCommand                  | EditorViewModel.UndoCommand          | `ICommand`                                     | View → VM |
+| EditorPage    | RedoCommand                  | EditorViewModel.RedoCommand          | `ICommand`                                     | View → VM |
+| SettingsPage  | SavePath                     | SettingsViewModel.SavePath           | `string`                                       | View ↔ VM |
+| SettingsPage  | ImageFormat                  | SettingsViewModel.ImageFormat        | `string`                                       | View ↔ VM |
+| SettingsPage  | Hotkeys                      | SettingsViewModel.Hotkeys            | `AppSettings`                                  | View ↔ VM |
+| SettingsPage  | SaveCommand                  | SettingsViewModel.SaveCommand        | `ICommand`                                     | View → VM |
+
+### ナビゲーション構成
+
+```
+AppShell (Shell)
+  └── WorkspacePage (デフォルト)
+        ├── → EditorPage (アイテムタップ時)
+        └── → SettingsPage (設定ボタンタップ時)
+```
+
+### DI 登録（MauiProgram.cs）
+
+```csharp
+builder.Services.AddTransient<WorkspaceViewModel>();
+builder.Services.AddTransient<WorkspacePage>();
+builder.Services.AddTransient<EditorViewModel>();
+builder.Services.AddTransient<EditorPage>();
+builder.Services.AddTransient<SettingsViewModel>();
+builder.Services.AddTransient<SettingsPage>();
+```
+
+---
+
+## 4. 共通コンポーネント（MAUI対応）
+
+| 既存 React コンポーネント | MAUI 対応                                    | 種類                 |
+| ------------------------- | -------------------------------------------- | -------------------- |
+| `ThumbnailGrid`           | `CollectionView` + `GridItemsLayout`         | 標準コントロール     |
+| `SearchBar`               | `SearchBar`                                  | 標準コントロール     |
+| `TagFilterBar`            | `HorizontalStackLayout` + `Button` or `Chip` | カスタム             |
+| `TagInput`                | `Entry` + `HorizontalStackLayout`            | カスタム             |
+| `Toolbar`                 | `HorizontalStackLayout` + `ImageButton`      | カスタム             |
+| `EditorToolbar`           | `HorizontalStackLayout` + `Button`           | カスタム             |
+| `EditorCanvas`            | `GraphicsView` (MAUI Graphics) or SkiaSharp  | カスタム             |
+| `ErrorBoundary`           | `try-catch` + Serilog logging                | コード               |
+| `DetailPanel`             | `ScrollView` + `VerticalStackLayout`         | カスタム             |
+| `RegionCaptureOverlay`    | `Window` + `GraphicsView` (フルスクリーン)   | プラットフォーム固有 |
+| `WindowCaptureOverlay`    | `Window` + リスト                            | プラットフォーム固有 |


### PR DESCRIPTION
## Summary

- 3画面（Workspace/Editor/Settings）のアスキーアートワイヤーフレーム作成
- MVVM構成の View ↔ ViewModel バインディング対応表（15項目）を確定
- ナビゲーション構成（Shell → Workspace → Editor/Settings）とDI登録方針を定義
- 共通コンポーネントの React → MAUI 対応マッピング

Closes #176