### PR TITLE
feat: Phase 2 data layer - Repositories, StorageService, Settings DTO, and Compatibility Tests

### DIFF
--- a/src-dotnet/AmeCapture.Application/Interfaces/IDbConnectionFactory.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/IDbConnectionFactory.cs
@@ -1,0 +1,9 @@
+using System.Data.Common;
+
+namespace AmeCapture.Application.Interfaces;
+
+public interface IDbConnectionFactory
+{
+    Task<DbConnection> CreateConnectionAsync();
+    string DatabasePath { get; }
+}

--- a/src-dotnet/AmeCapture.Application/Interfaces/IStorageService.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/IStorageService.cs
@@ -1,0 +1,16 @@
+namespace AmeCapture.Application.Interfaces;
+
+public interface IStorageService
+{
+    Task EnsureDirectoriesAsync();
+    string GetBasePath();
+    string ResolveOriginalPath(string filename);
+    string ResolveEditedPath(string filename);
+    string ResolveThumbnailPath(string originalFilename);
+    string ResolveVideoPath(string filename);
+    string GetOriginalsDir();
+    string GetEditedDir();
+    string GetThumbnailsDir();
+    string GetVideosDir();
+    string GenerateThumbnailFilename(string originalFilename);
+}

--- a/src-dotnet/AmeCapture.Application/Interfaces/ITagRepository.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/ITagRepository.cs
@@ -5,8 +5,14 @@ namespace AmeCapture.Application.Interfaces;
 public interface ITagRepository
 {
     Task<IReadOnlyList<Tag>> GetAllAsync();
-    Task<Tag> CreateAsync(Tag tag);
+    Task<Tag?> GetByIdAsync(string id);
+    Task<Tag?> FindByNameAsync(string name);
+    Task AddAsync(Tag tag);
     Task DeleteAsync(string id);
     Task<IReadOnlyList<Tag>> GetTagsForItemAsync(string itemId);
+    Task AddTagToItemAsync(string itemId, string tagId);
+    Task RemoveTagFromItemAsync(string itemId, string tagId);
     Task SetTagsForItemAsync(string itemId, IEnumerable<string> tagIds);
+    Task<IReadOnlyList<string>> GetItemIdsByTagAsync(string tagId);
+    Task<IReadOnlyDictionary<string, IReadOnlyList<Tag>>> GetAllTagsForItemsAsync(IEnumerable<string> itemIds);
 }

--- a/src-dotnet/AmeCapture.Application/Interfaces/IWorkspaceRepository.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/IWorkspaceRepository.cs
@@ -9,4 +9,5 @@ public interface IWorkspaceRepository
     Task AddAsync(WorkspaceItem item);
     Task UpdateAsync(WorkspaceItem item);
     Task DeleteAsync(string id);
+    Task<IReadOnlyList<WorkspaceItem>> GetByIdsAsync(IEnumerable<string> ids);
 }

--- a/src-dotnet/AmeCapture.Domain/Entities/AppSettings.cs
+++ b/src-dotnet/AmeCapture.Domain/Entities/AppSettings.cs
@@ -4,7 +4,8 @@ public class AppSettings
 {
     public string SavePath { get; set; } = string.Empty;
     public string ImageFormat { get; set; } = "png";
-    public string HotkeyCapture { get; set; } = "Ctrl+Shift+S";
-    public string HotkeyRegionCapture { get; set; } = "Ctrl+Shift+F";
-    public string HotkeyWindowCapture { get; set; } = "Ctrl+Shift+W";
+    public bool StartMinimized { get; set; }
+    public string HotkeyCaptureRegion { get; set; } = "Ctrl+Shift+S";
+    public string HotkeyCaptureFullscreen { get; set; } = "Ctrl+Shift+F";
+    public string HotkeyCaptureWindow { get; set; } = "Ctrl+Shift+W";
 }

--- a/src-dotnet/AmeCapture.Domain/Entities/WorkspaceItem.cs
+++ b/src-dotnet/AmeCapture.Domain/Entities/WorkspaceItem.cs
@@ -14,8 +14,8 @@ public class WorkspaceItem
     public string CurrentPath { get; set; } = string.Empty;
     public string? ThumbnailPath { get; set; }
     public string Title { get; set; } = string.Empty;
-    public DateTimeOffset CreatedAt { get; set; }
-    public DateTimeOffset UpdatedAt { get; set; }
+    public string CreatedAt { get; set; } = string.Empty;
+    public string UpdatedAt { get; set; } = string.Empty;
     public bool IsFavorite { get; set; }
     public string? MetadataJson { get; set; }
 }

--- a/src-dotnet/AmeCapture.Infrastructure/AmeCapture.Infrastructure.csproj
+++ b/src-dotnet/AmeCapture.Infrastructure/AmeCapture.Infrastructure.csproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\AmeCapture.Application\AmeCapture.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src-dotnet/AmeCapture.Infrastructure/Database/DatabaseInitializer.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Database/DatabaseInitializer.cs
@@ -7,7 +7,9 @@ public static class DatabaseInitializer
     public static async Task InitializeAsync(IDbConnectionFactory connectionFactory)
     {
         using var connection = await connectionFactory.CreateConnectionAsync();
+        using var transaction = await connection.BeginTransactionAsync();
         using var command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = @"
             CREATE TABLE IF NOT EXISTS workspace_items (
                 id TEXT PRIMARY KEY,
@@ -45,5 +47,6 @@ public static class DatabaseInitializer
             CREATE INDEX IF NOT EXISTS idx_workspace_items_is_favorite
                 ON workspace_items(is_favorite);";
         await command.ExecuteNonQueryAsync();
+        await transaction.CommitAsync();
     }
 }

--- a/src-dotnet/AmeCapture.Infrastructure/Database/DatabaseInitializer.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Database/DatabaseInitializer.cs
@@ -1,0 +1,49 @@
+using AmeCapture.Application.Interfaces;
+
+namespace AmeCapture.Infrastructure.Database;
+
+public static class DatabaseInitializer
+{
+    public static async Task InitializeAsync(IDbConnectionFactory connectionFactory)
+    {
+        using var connection = await connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            CREATE TABLE IF NOT EXISTS workspace_items (
+                id TEXT PRIMARY KEY,
+                type TEXT NOT NULL DEFAULT 'image',
+                original_path TEXT NOT NULL,
+                current_path TEXT NOT NULL,
+                thumbnail_path TEXT,
+                title TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                is_favorite INTEGER NOT NULL DEFAULT 0,
+                metadata_json TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS tags (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+
+            CREATE TABLE IF NOT EXISTS workspace_item_tags (
+                workspace_item_id TEXT NOT NULL,
+                tag_id TEXT NOT NULL,
+                PRIMARY KEY (workspace_item_id, tag_id),
+                FOREIGN KEY (workspace_item_id) REFERENCES workspace_items(id) ON DELETE CASCADE,
+                FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS app_settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_workspace_items_created_at
+                ON workspace_items(created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_workspace_items_is_favorite
+                ON workspace_items(is_favorite);";
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Database/SqliteConnectionFactory.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Database/SqliteConnectionFactory.cs
@@ -1,0 +1,31 @@
+using System.Data.Common;
+using AmeCapture.Application.Interfaces;
+using Microsoft.Data.Sqlite;
+
+namespace AmeCapture.Infrastructure.Database;
+
+public class SqliteConnectionFactory : IDbConnectionFactory
+{
+    private readonly string _connectionString;
+    private readonly string _databasePath;
+
+    public SqliteConnectionFactory(string databasePath)
+    {
+        _databasePath = databasePath;
+        _connectionString = $"Data Source={databasePath};Pooling=False";
+    }
+
+    public string DatabasePath => _databasePath;
+
+    public async Task<DbConnection> CreateConnectionAsync()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
+        await cmd.ExecuteNonQueryAsync();
+
+        return connection;
+    }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Repositories/SettingsRepository.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Repositories/SettingsRepository.cs
@@ -1,0 +1,100 @@
+using System.Data.Common;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Domain.Entities;
+
+namespace AmeCapture.Infrastructure.Repositories;
+
+public class SettingsRepository : ISettingsRepository
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public SettingsRepository(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<AppSettings> GetAsync()
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT key, value FROM app_settings ORDER BY key";
+
+        var settings = new AppSettings();
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var key = reader.GetString(0);
+            var value = reader.GetString(1);
+
+            switch (key)
+            {
+                case "save_path":
+                    settings.SavePath = value;
+                    break;
+                case "image_format":
+                    settings.ImageFormat = value;
+                    break;
+                case "start_minimized":
+                    settings.StartMinimized = value == "true";
+                    break;
+                case "hotkey_capture_region":
+                    settings.HotkeyCaptureRegion = value;
+                    break;
+                case "hotkey_capture_fullscreen":
+                    settings.HotkeyCaptureFullscreen = value;
+                    break;
+                case "hotkey_capture_window":
+                    settings.HotkeyCaptureWindow = value;
+                    break;
+            }
+        }
+
+        return settings;
+    }
+
+    public async Task SaveAsync(AppSettings settings)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var transaction = await connection.BeginTransactionAsync();
+
+        try
+        {
+            await UpsertAsync(connection, transaction, "save_path", settings.SavePath);
+            await UpsertAsync(connection, transaction, "image_format", settings.ImageFormat);
+            await UpsertAsync(connection, transaction, "start_minimized",
+                settings.StartMinimized ? "true" : "false");
+            await UpsertAsync(connection, transaction, "hotkey_capture_region", settings.HotkeyCaptureRegion);
+            await UpsertAsync(connection, transaction, "hotkey_capture_fullscreen", settings.HotkeyCaptureFullscreen);
+            await UpsertAsync(connection, transaction, "hotkey_capture_window", settings.HotkeyCaptureWindow);
+
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
+    private static async Task UpsertAsync(DbConnection connection, DbTransaction transaction,
+        string key, string value)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = @"
+            INSERT INTO app_settings (key, value) VALUES (@key, @value)
+            ON CONFLICT(key) DO UPDATE SET value = @value";
+        var keyParam = command.CreateParameter();
+        keyParam.ParameterName = "@key";
+        keyParam.Value = key;
+        command.Parameters.Add(keyParam);
+
+        var valueParam = command.CreateParameter();
+        valueParam.ParameterName = "@value";
+        valueParam.Value = value;
+        command.Parameters.Add(valueParam);
+
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Repositories/TagRepository.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Repositories/TagRepository.cs
@@ -143,15 +143,21 @@ public class TagRepository : ITagRepository
                 await deleteCommand.ExecuteNonQueryAsync();
             }
 
-            foreach (var tagId in tagIds)
+            using (var insertCommand = connection.CreateCommand())
             {
-                using var insertCommand = connection.CreateCommand();
                 insertCommand.Transaction = transaction;
                 insertCommand.CommandText = @"
                     INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (@itemId, @tagId)";
                 AddParameter(insertCommand, "@itemId", itemId);
-                AddParameter(insertCommand, "@tagId", tagId);
-                await insertCommand.ExecuteNonQueryAsync();
+                var tagParam = insertCommand.CreateParameter();
+                tagParam.ParameterName = "@tagId";
+                insertCommand.Parameters.Add(tagParam);
+
+                foreach (var tagId in tagIds)
+                {
+                    tagParam.Value = tagId;
+                    await insertCommand.ExecuteNonQueryAsync();
+                }
             }
 
             await transaction.CommitAsync();
@@ -190,36 +196,43 @@ public class TagRepository : ITagRepository
             return new Dictionary<string, IReadOnlyList<Tag>>();
         }
 
-        using var connection = await _connectionFactory.CreateConnectionAsync();
-        using var command = connection.CreateCommand();
-
-        var placeholders = new List<string>();
-        for (var i = 0; i < idList.Count; i++)
-        {
-            var paramName = $"@id{i}";
-            placeholders.Add(paramName);
-            AddParameter(command, paramName, idList[i]);
-        }
-
-        command.CommandText = $@"
-            SELECT wit.workspace_item_id, t.id, t.name
-            FROM workspace_item_tags wit
-            INNER JOIN tags t ON t.id = wit.tag_id
-            WHERE wit.workspace_item_id IN ({string.Join(", ", placeholders)})
-            ORDER BY t.name";
-
         var map = new Dictionary<string, IReadOnlyList<Tag>>();
         foreach (var id in idList)
         {
             map[id] = new List<Tag>();
         }
 
-        using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        const int chunkSize = 500;
+
+        for (var chunkStart = 0; chunkStart < idList.Count; chunkStart += chunkSize)
         {
-            var itemId = reader.GetString(0);
-            var tag = new Tag { Id = reader.GetString(1), Name = reader.GetString(2) };
-            ((List<Tag>)map[itemId]).Add(tag);
+            var chunk = idList.Skip(chunkStart).Take(chunkSize).ToList();
+
+            using var connection = await _connectionFactory.CreateConnectionAsync();
+            using var command = connection.CreateCommand();
+
+            var placeholders = new List<string>();
+            for (var i = 0; i < chunk.Count; i++)
+            {
+                var paramName = $"@id{i}";
+                placeholders.Add(paramName);
+                AddParameter(command, paramName, chunk[i]);
+            }
+
+            command.CommandText = $@"
+            SELECT wit.workspace_item_id, t.id, t.name
+            FROM workspace_item_tags wit
+            INNER JOIN tags t ON t.id = wit.tag_id
+            WHERE wit.workspace_item_id IN ({string.Join(", ", placeholders)})
+            ORDER BY t.name";
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var itemId = reader.GetString(0);
+                var tag = new Tag { Id = reader.GetString(1), Name = reader.GetString(2) };
+                ((List<Tag>)map[itemId]).Add(tag);
+            }
         }
 
         return map;

--- a/src-dotnet/AmeCapture.Infrastructure/Repositories/TagRepository.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Repositories/TagRepository.cs
@@ -1,0 +1,240 @@
+using System.Data.Common;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Domain.Entities;
+
+namespace AmeCapture.Infrastructure.Repositories;
+
+public class TagRepository : ITagRepository
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public TagRepository(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<IReadOnlyList<Tag>> GetAllAsync()
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT id, name FROM tags ORDER BY name";
+
+        var tags = new List<Tag>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            tags.Add(ReadTag(reader));
+        }
+
+        return tags.AsReadOnly();
+    }
+
+    public async Task<Tag?> GetByIdAsync(string id)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT id, name FROM tags WHERE id = @id";
+        AddParameter(command, "@id", id);
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return ReadTag(reader);
+        }
+
+        return null;
+    }
+
+    public async Task<Tag?> FindByNameAsync(string name)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT id, name FROM tags WHERE name = @name";
+        AddParameter(command, "@name", name);
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return ReadTag(reader);
+        }
+
+        return null;
+    }
+
+    public async Task AddAsync(Tag tag)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "INSERT INTO tags (id, name) VALUES (@id, @name)";
+        AddParameter(command, "@id", tag.Id);
+        AddParameter(command, "@name", tag.Name);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM tags WHERE id = @id";
+        AddParameter(command, "@id", id);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task<IReadOnlyList<Tag>> GetTagsForItemAsync(string itemId)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            SELECT t.id, t.name FROM tags t
+            INNER JOIN workspace_item_tags wit ON t.id = wit.tag_id
+            WHERE wit.workspace_item_id = @itemId
+            ORDER BY t.name";
+        AddParameter(command, "@itemId", itemId);
+
+        var tags = new List<Tag>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            tags.Add(ReadTag(reader));
+        }
+
+        return tags.AsReadOnly();
+    }
+
+    public async Task AddTagToItemAsync(string itemId, string tagId)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (@itemId, @tagId)";
+        AddParameter(command, "@itemId", itemId);
+        AddParameter(command, "@tagId", tagId);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task RemoveTagFromItemAsync(string itemId, string tagId)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            DELETE FROM workspace_item_tags WHERE workspace_item_id = @itemId AND tag_id = @tagId";
+        AddParameter(command, "@itemId", itemId);
+        AddParameter(command, "@tagId", tagId);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task SetTagsForItemAsync(string itemId, IEnumerable<string> tagIds)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var transaction = await connection.BeginTransactionAsync();
+
+        try
+        {
+            using (var deleteCommand = connection.CreateCommand())
+            {
+                deleteCommand.Transaction = transaction;
+                deleteCommand.CommandText =
+                    "DELETE FROM workspace_item_tags WHERE workspace_item_id = @itemId";
+                AddParameter(deleteCommand, "@itemId", itemId);
+                await deleteCommand.ExecuteNonQueryAsync();
+            }
+
+            foreach (var tagId in tagIds)
+            {
+                using var insertCommand = connection.CreateCommand();
+                insertCommand.Transaction = transaction;
+                insertCommand.CommandText = @"
+                    INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (@itemId, @tagId)";
+                AddParameter(insertCommand, "@itemId", itemId);
+                AddParameter(insertCommand, "@tagId", tagId);
+                await insertCommand.ExecuteNonQueryAsync();
+            }
+
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetItemIdsByTagAsync(string tagId)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT workspace_item_id FROM workspace_item_tags WHERE tag_id = @tagId";
+        AddParameter(command, "@tagId", tagId);
+
+        var ids = new List<string>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            ids.Add(reader.GetString(0));
+        }
+
+        return ids.AsReadOnly();
+    }
+
+    public async Task<IReadOnlyDictionary<string, IReadOnlyList<Tag>>> GetAllTagsForItemsAsync(
+        IEnumerable<string> itemIds)
+    {
+        var idList = itemIds.ToList();
+        if (idList.Count == 0)
+        {
+            return new Dictionary<string, IReadOnlyList<Tag>>();
+        }
+
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var placeholders = new List<string>();
+        for (var i = 0; i < idList.Count; i++)
+        {
+            var paramName = $"@id{i}";
+            placeholders.Add(paramName);
+            AddParameter(command, paramName, idList[i]);
+        }
+
+        command.CommandText = $@"
+            SELECT wit.workspace_item_id, t.id, t.name
+            FROM workspace_item_tags wit
+            INNER JOIN tags t ON t.id = wit.tag_id
+            WHERE wit.workspace_item_id IN ({string.Join(", ", placeholders)})
+            ORDER BY t.name";
+
+        var map = new Dictionary<string, IReadOnlyList<Tag>>();
+        foreach (var id in idList)
+        {
+            map[id] = new List<Tag>();
+        }
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var itemId = reader.GetString(0);
+            var tag = new Tag { Id = reader.GetString(1), Name = reader.GetString(2) };
+            ((List<Tag>)map[itemId]).Add(tag);
+        }
+
+        return map;
+    }
+
+    private static Tag ReadTag(DbDataReader reader)
+    {
+        return new Tag { Id = reader.GetString(0), Name = reader.GetString(1) };
+    }
+
+    private static void AddParameter(DbCommand command, string name, object value)
+    {
+        var param = command.CreateParameter();
+        param.ParameterName = name;
+        param.Value = value;
+        command.Parameters.Add(param);
+    }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Repositories/WorkspaceRepository.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Repositories/WorkspaceRepository.cs
@@ -119,30 +119,37 @@ public class WorkspaceRepository : IWorkspaceRepository
             return Array.Empty<WorkspaceItem>();
         }
 
-        using var connection = await _connectionFactory.CreateConnectionAsync();
-        using var command = connection.CreateCommand();
+        var allItems = new List<WorkspaceItem>();
+        const int chunkSize = 500;
 
-        var placeholders = new List<string>();
-        for (var i = 0; i < idList.Count; i++)
+        for (var chunkStart = 0; chunkStart < idList.Count; chunkStart += chunkSize)
         {
-            var paramName = $"@id{i}";
-            placeholders.Add(paramName);
-            AddParameter(command, paramName, idList[i]);
-        }
+            var chunk = idList.Skip(chunkStart).Take(chunkSize).ToList();
 
-        command.CommandText = $@"
+            using var connection = await _connectionFactory.CreateConnectionAsync();
+            using var command = connection.CreateCommand();
+
+            var placeholders = new List<string>();
+            for (var i = 0; i < chunk.Count; i++)
+            {
+                var paramName = $"@id{i}";
+                placeholders.Add(paramName);
+                AddParameter(command, paramName, chunk[i]);
+            }
+
+            command.CommandText = $@"
             SELECT id, type, original_path, current_path, thumbnail_path,
                    title, created_at, updated_at, is_favorite, metadata_json
             FROM workspace_items WHERE id IN ({string.Join(", ", placeholders)})";
 
-        var items = new List<WorkspaceItem>();
-        using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            items.Add(ReadWorkspaceItem(reader));
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                allItems.Add(ReadWorkspaceItem(reader));
+            }
         }
 
-        return items.AsReadOnly();
+        return allItems.AsReadOnly();
     }
 
     private static WorkspaceItem ReadWorkspaceItem(DbDataReader reader)

--- a/src-dotnet/AmeCapture.Infrastructure/Repositories/WorkspaceRepository.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Repositories/WorkspaceRepository.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using AmeCapture.Application.Interfaces;
 using AmeCapture.Domain.Entities;
 
@@ -5,29 +6,173 @@ namespace AmeCapture.Infrastructure.Repositories;
 
 public class WorkspaceRepository : IWorkspaceRepository
 {
-    public Task<IReadOnlyList<WorkspaceItem>> GetAllAsync()
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public WorkspaceRepository(IDbConnectionFactory connectionFactory)
     {
-        IReadOnlyList<WorkspaceItem> result = Array.Empty<WorkspaceItem>();
-        return Task.FromResult(result);
+        _connectionFactory = connectionFactory;
     }
 
-    public Task<WorkspaceItem?> GetByIdAsync(string id)
+    public async Task<IReadOnlyList<WorkspaceItem>> GetAllAsync()
     {
-        return Task.FromResult<WorkspaceItem?>(null);
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            SELECT id, type, original_path, current_path, thumbnail_path,
+                   title, created_at, updated_at, is_favorite, metadata_json
+            FROM workspace_items
+            ORDER BY created_at DESC";
+
+        var items = new List<WorkspaceItem>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(ReadWorkspaceItem(reader));
+        }
+
+        return items.AsReadOnly();
     }
 
-    public Task AddAsync(WorkspaceItem item)
+    public async Task<WorkspaceItem?> GetByIdAsync(string id)
     {
-        return Task.CompletedTask;
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            SELECT id, type, original_path, current_path, thumbnail_path,
+                   title, created_at, updated_at, is_favorite, metadata_json
+            FROM workspace_items WHERE id = @id";
+        AddParameter(command, "@id", id);
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return ReadWorkspaceItem(reader);
+        }
+
+        return null;
     }
 
-    public Task UpdateAsync(WorkspaceItem item)
+    public async Task AddAsync(WorkspaceItem item)
     {
-        return Task.CompletedTask;
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            INSERT INTO workspace_items
+                (id, type, original_path, current_path, thumbnail_path,
+                 title, created_at, updated_at, is_favorite, metadata_json)
+            VALUES (@id, @type, @original_path, @current_path, @thumbnail_path,
+                    @title, @created_at, @updated_at, @is_favorite, @metadata_json)";
+
+        AddParameter(command, "@id", item.Id);
+        AddParameter(command, "@type", ItemTypeToString(item.ItemType));
+        AddParameter(command, "@original_path", item.OriginalPath);
+        AddParameter(command, "@current_path", item.CurrentPath);
+        AddParameter(command, "@thumbnail_path", (object?)item.ThumbnailPath ?? DBNull.Value);
+        AddParameter(command, "@title", item.Title);
+        AddParameter(command, "@created_at", item.CreatedAt);
+        AddParameter(command, "@updated_at", item.UpdatedAt);
+        AddParameter(command, "@is_favorite", item.IsFavorite ? 1 : 0);
+        AddParameter(command, "@metadata_json", (object?)item.MetadataJson ?? DBNull.Value);
+
+        await command.ExecuteNonQueryAsync();
     }
 
-    public Task DeleteAsync(string id)
+    public async Task UpdateAsync(WorkspaceItem item)
     {
-        return Task.CompletedTask;
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            UPDATE workspace_items SET
+                type = @type, original_path = @original_path, current_path = @current_path,
+                thumbnail_path = @thumbnail_path, title = @title, updated_at = @updated_at,
+                is_favorite = @is_favorite, metadata_json = @metadata_json
+            WHERE id = @id";
+
+        AddParameter(command, "@type", ItemTypeToString(item.ItemType));
+        AddParameter(command, "@original_path", item.OriginalPath);
+        AddParameter(command, "@current_path", item.CurrentPath);
+        AddParameter(command, "@thumbnail_path", (object?)item.ThumbnailPath ?? DBNull.Value);
+        AddParameter(command, "@title", item.Title);
+        AddParameter(command, "@updated_at", item.UpdatedAt);
+        AddParameter(command, "@is_favorite", item.IsFavorite ? 1 : 0);
+        AddParameter(command, "@metadata_json", (object?)item.MetadataJson ?? DBNull.Value);
+        AddParameter(command, "@id", item.Id);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM workspace_items WHERE id = @id";
+        AddParameter(command, "@id", id);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task<IReadOnlyList<WorkspaceItem>> GetByIdsAsync(IEnumerable<string> ids)
+    {
+        var idList = ids.ToList();
+        if (idList.Count == 0)
+        {
+            return Array.Empty<WorkspaceItem>();
+        }
+
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var placeholders = new List<string>();
+        for (var i = 0; i < idList.Count; i++)
+        {
+            var paramName = $"@id{i}";
+            placeholders.Add(paramName);
+            AddParameter(command, paramName, idList[i]);
+        }
+
+        command.CommandText = $@"
+            SELECT id, type, original_path, current_path, thumbnail_path,
+                   title, created_at, updated_at, is_favorite, metadata_json
+            FROM workspace_items WHERE id IN ({string.Join(", ", placeholders)})";
+
+        var items = new List<WorkspaceItem>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(ReadWorkspaceItem(reader));
+        }
+
+        return items.AsReadOnly();
+    }
+
+    private static WorkspaceItem ReadWorkspaceItem(DbDataReader reader)
+    {
+        var typeStr = reader.GetString(1);
+        return new WorkspaceItem
+        {
+            Id = reader.GetString(0),
+            ItemType = typeStr == "video" ? WorkspaceItemType.Video : WorkspaceItemType.Image,
+            OriginalPath = reader.GetString(2),
+            CurrentPath = reader.GetString(3),
+            ThumbnailPath = reader.IsDBNull(4) ? null : reader.GetString(4),
+            Title = reader.GetString(5),
+            CreatedAt = reader.GetString(6),
+            UpdatedAt = reader.GetString(7),
+            IsFavorite = reader.GetInt32(8) != 0,
+            MetadataJson = reader.IsDBNull(9) ? null : reader.GetString(9)
+        };
+    }
+
+    private static string ItemTypeToString(WorkspaceItemType type)
+    {
+        return type == WorkspaceItemType.Video ? "video" : "image";
+    }
+
+    private static void AddParameter(DbCommand command, string name, object value)
+    {
+        var param = command.CreateParameter();
+        param.ParameterName = name;
+        param.Value = value;
+        command.Parameters.Add(param);
     }
 }

--- a/src-dotnet/AmeCapture.Infrastructure/Services/StorageService.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/StorageService.cs
@@ -1,0 +1,60 @@
+using AmeCapture.Application.Interfaces;
+
+namespace AmeCapture.Infrastructure.Services;
+
+public class StorageService : IStorageService
+{
+    private const string DirOriginals = "originals";
+    private const string DirEdited = "edited";
+    private const string DirThumbnails = "thumbnails";
+    private const string DirVideos = "videos";
+
+    private readonly string _basePath;
+
+    public StorageService(string basePath)
+    {
+        _basePath = basePath;
+    }
+
+    public string GetBasePath() => _basePath;
+
+    public async Task EnsureDirectoriesAsync()
+    {
+        var dirs = new[] { DirOriginals, DirEdited, DirThumbnails, DirVideos };
+        foreach (var dir in dirs)
+        {
+            var path = Path.Combine(_basePath, dir);
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public string ResolveOriginalPath(string filename) => Path.Combine(_basePath, DirOriginals, filename);
+    public string ResolveEditedPath(string filename) => Path.Combine(_basePath, DirEdited, filename);
+    public string ResolveThumbnailPath(string originalFilename) =>
+        Path.Combine(_basePath, DirThumbnails, GenerateThumbnailFilename(originalFilename));
+    public string ResolveVideoPath(string filename) => Path.Combine(_basePath, DirVideos, filename);
+
+    public string GetOriginalsDir() => Path.Combine(_basePath, DirOriginals);
+    public string GetEditedDir() => Path.Combine(_basePath, DirEdited);
+    public string GetThumbnailsDir() => Path.Combine(_basePath, DirThumbnails);
+    public string GetVideosDir() => Path.Combine(_basePath, DirVideos);
+
+    public string GenerateThumbnailFilename(string originalFilename)
+    {
+        var fileName = Path.GetFileName(originalFilename);
+        var extension = Path.GetExtension(fileName);
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+
+        if (!string.IsNullOrEmpty(extension))
+        {
+            return $"{nameWithoutExtension}_thumb{extension}";
+        }
+
+        return $"{nameWithoutExtension}_thumb";
+    }
+}

--- a/src-dotnet/AmeCapture.Tests/AmeCapture.Tests.csproj
+++ b/src-dotnet/AmeCapture.Tests/AmeCapture.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/src-dotnet/AmeCapture.Tests/Domain/EntityTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Domain/EntityTests.cs
@@ -1,6 +1,6 @@
 using AmeCapture.Domain.Entities;
 
-namespace AmeCapture.Tests;
+namespace AmeCapture.Tests.Domain;
 
 public class WorkspaceItemTests
 {
@@ -15,6 +15,8 @@ public class WorkspaceItemTests
         Assert.Equal(string.Empty, item.CurrentPath);
         Assert.Null(item.ThumbnailPath);
         Assert.Equal(string.Empty, item.Title);
+        Assert.Equal(string.Empty, item.CreatedAt);
+        Assert.Equal(string.Empty, item.UpdatedAt);
         Assert.False(item.IsFavorite);
         Assert.Null(item.MetadataJson);
     }
@@ -35,8 +37,9 @@ public class WorkspaceItemTests
 
         Assert.Equal(string.Empty, settings.SavePath);
         Assert.Equal("png", settings.ImageFormat);
-        Assert.Equal("Ctrl+Shift+S", settings.HotkeyCapture);
-        Assert.Equal("Ctrl+Shift+F", settings.HotkeyRegionCapture);
-        Assert.Equal("Ctrl+Shift+W", settings.HotkeyWindowCapture);
+        Assert.False(settings.StartMinimized);
+        Assert.Equal("Ctrl+Shift+S", settings.HotkeyCaptureRegion);
+        Assert.Equal("Ctrl+Shift+F", settings.HotkeyCaptureFullscreen);
+        Assert.Equal("Ctrl+Shift+W", settings.HotkeyCaptureWindow);
     }
 }

--- a/src-dotnet/AmeCapture.Tests/Integration/SettingsRepositoryTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Integration/SettingsRepositoryTests.cs
@@ -1,0 +1,90 @@
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Domain.Entities;
+using AmeCapture.Infrastructure.Database;
+using AmeCapture.Infrastructure.Repositories;
+
+namespace AmeCapture.Tests.Integration;
+
+public class SettingsRepositoryTests : IAsyncLifetime
+{
+    private readonly string _dbPath;
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly SettingsRepository _repo;
+
+    public SettingsRepositoryTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.db");
+        _connectionFactory = new SqliteConnectionFactory(_dbPath);
+        _repo = new SettingsRepository(_connectionFactory);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await DatabaseInitializer.InitializeAsync(_connectionFactory);
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (File.Exists(_dbPath))
+            {
+                File.Delete(_dbPath);
+            }
+        }
+        catch
+        {
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task GetAsync_EmptyDb_ReturnsDefaultSettings()
+    {
+        var settings = await _repo.GetAsync();
+
+        Assert.Equal(string.Empty, settings.SavePath);
+        Assert.Equal("png", settings.ImageFormat);
+        Assert.False(settings.StartMinimized);
+        Assert.Equal("Ctrl+Shift+S", settings.HotkeyCaptureRegion);
+        Assert.Equal("Ctrl+Shift+F", settings.HotkeyCaptureFullscreen);
+        Assert.Equal("Ctrl+Shift+W", settings.HotkeyCaptureWindow);
+    }
+
+    [Fact]
+    public async Task SaveAsync_And_GetAsync_Roundtrip()
+    {
+        var settings = new AppSettings
+        {
+            SavePath = "/home/user/Pictures/AmeCapture",
+            ImageFormat = "jpg",
+            StartMinimized = true,
+            HotkeyCaptureRegion = "Ctrl+Alt+S",
+            HotkeyCaptureFullscreen = "Ctrl+Alt+F",
+            HotkeyCaptureWindow = "Ctrl+Alt+W"
+        };
+
+        await _repo.SaveAsync(settings);
+        var loaded = await _repo.GetAsync();
+
+        Assert.Equal("/home/user/Pictures/AmeCapture", loaded.SavePath);
+        Assert.Equal("jpg", loaded.ImageFormat);
+        Assert.True(loaded.StartMinimized);
+        Assert.Equal("Ctrl+Alt+S", loaded.HotkeyCaptureRegion);
+        Assert.Equal("Ctrl+Alt+F", loaded.HotkeyCaptureFullscreen);
+        Assert.Equal("Ctrl+Alt+W", loaded.HotkeyCaptureWindow);
+    }
+
+    [Fact]
+    public async Task SaveAsync_UpdatesExistingSettings()
+    {
+        var settings = new AppSettings { SavePath = "/original" };
+        await _repo.SaveAsync(settings);
+
+        settings.SavePath = "/updated";
+        await _repo.SaveAsync(settings);
+
+        var loaded = await _repo.GetAsync();
+        Assert.Equal("/updated", loaded.SavePath);
+    }
+}

--- a/src-dotnet/AmeCapture.Tests/Integration/SqliteCompatibilityTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Integration/SqliteCompatibilityTests.cs
@@ -1,0 +1,139 @@
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Domain.Entities;
+using AmeCapture.Infrastructure.Database;
+using AmeCapture.Infrastructure.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace AmeCapture.Tests.Integration;
+
+public class SqliteCompatibilityTests : IAsyncLifetime
+{
+    private readonly string _dbPath;
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly WorkspaceRepository _workspaceRepo;
+    private readonly TagRepository _tagRepo;
+    private readonly SettingsRepository _settingsRepo;
+
+    public SqliteCompatibilityTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.db");
+        _connectionFactory = new SqliteConnectionFactory(_dbPath);
+        _workspaceRepo = new WorkspaceRepository(_connectionFactory);
+        _tagRepo = new TagRepository(_connectionFactory);
+        _settingsRepo = new SettingsRepository(_connectionFactory);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await DatabaseInitializer.InitializeAsync(_connectionFactory);
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (File.Exists(_dbPath))
+            {
+                File.Delete(_dbPath);
+            }
+        }
+        catch
+        {
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task DatabaseInitializer_CreatesAllTables()
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name";
+
+        var tables = new List<string>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            tables.Add(reader.GetString(0));
+        }
+
+        Assert.Contains("workspace_items", tables);
+        Assert.Contains("tags", tables);
+        Assert.Contains("workspace_item_tags", tables);
+        Assert.Contains("app_settings", tables);
+    }
+
+    [Fact]
+    public async Task DatabaseInitializer_CreatesIndexes()
+    {
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name";
+
+        var indexes = new List<string>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            indexes.Add(reader.GetString(0));
+        }
+
+        Assert.Contains("idx_workspace_items_created_at", indexes);
+        Assert.Contains("idx_workspace_items_is_favorite", indexes);
+    }
+
+    [Fact]
+    public async Task DatabaseInitializer_IsIdempotent()
+    {
+        await DatabaseInitializer.InitializeAsync(_connectionFactory);
+        await DatabaseInitializer.InitializeAsync(_connectionFactory);
+
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
+        var count = Convert.ToInt64(await command.ExecuteScalarAsync());
+        Assert.Equal(4L, count);
+    }
+
+    private static WorkspaceItem CreateSampleItem(string id) => new()
+    {
+        Id = id,
+        ItemType = WorkspaceItemType.Image,
+        OriginalPath = "/a.png",
+        CurrentPath = "/a.png",
+        Title = "test",
+        CreatedAt = "2026-01-01",
+        UpdatedAt = "2026-01-01"
+    };
+
+    [Fact]
+    public async Task ForeignKey_CascadeDelete_RemovesTagAssociations()
+    {
+        await _workspaceRepo.AddAsync(CreateSampleItem("w1"));
+        await _tagRepo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _tagRepo.AddTagToItemAsync("w1", "t1");
+
+        var tags = await _tagRepo.GetTagsForItemAsync("w1");
+        Assert.Single(tags);
+
+        await _workspaceRepo.DeleteAsync("w1");
+
+        var tagsAfterDelete = await _tagRepo.GetTagsForItemAsync("w1");
+        Assert.Empty(tagsAfterDelete);
+    }
+
+    [Fact]
+    public async Task ForeignKey_PreventsInvalidTagReference()
+    {
+        await _workspaceRepo.AddAsync(CreateSampleItem("w1"));
+
+        using var connection = await _connectionFactory.CreateConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "INSERT INTO workspace_item_tags (workspace_item_id, tag_id) VALUES ('w1', 'nonexistent')";
+
+        await Assert.ThrowsAsync<SqliteException>(() => command.ExecuteNonQueryAsync());
+    }
+}

--- a/src-dotnet/AmeCapture.Tests/Integration/StorageServiceTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Integration/StorageServiceTests.cs
@@ -1,0 +1,104 @@
+using AmeCapture.Infrastructure.Services;
+
+namespace AmeCapture.Tests.Integration;
+
+public class StorageServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly StorageService _service;
+
+    public StorageServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"test_storage_{Guid.NewGuid():N}");
+        _service = new StorageService(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureDirectoriesAsync_CreatesAllDirectories()
+    {
+        await _service.EnsureDirectoriesAsync();
+
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "originals")));
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "edited")));
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "thumbnails")));
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "videos")));
+    }
+
+    [Fact]
+    public async Task EnsureDirectoriesAsync_IsIdempotent()
+    {
+        await _service.EnsureDirectoriesAsync();
+        await _service.EnsureDirectoriesAsync();
+
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "originals")));
+    }
+
+    [Fact]
+    public void ResolveOriginalPath_ReturnsCorrectPath()
+    {
+        var path = _service.ResolveOriginalPath("a.png");
+        Assert.Equal(Path.Combine(_tempDir, "originals", "a.png"), path);
+    }
+
+    [Fact]
+    public void ResolveEditedPath_ReturnsCorrectPath()
+    {
+        var path = _service.ResolveEditedPath("a.png");
+        Assert.Equal(Path.Combine(_tempDir, "edited", "a.png"), path);
+    }
+
+    [Fact]
+    public void ResolveThumbnailPath_ReturnsCorrectPath()
+    {
+        var path = _service.ResolveThumbnailPath("a.png");
+        Assert.Equal(Path.Combine(_tempDir, "thumbnails", "a_thumb.png"), path);
+    }
+
+    [Fact]
+    public void ResolveVideoPath_ReturnsCorrectPath()
+    {
+        var path = _service.ResolveVideoPath("b.mp4");
+        Assert.Equal(Path.Combine(_tempDir, "videos", "b.mp4"), path);
+    }
+
+    [Fact]
+    public void GenerateThumbnailFilename_WithExtension()
+    {
+        Assert.Equal("capture_001_thumb.png", _service.GenerateThumbnailFilename("capture_001.png"));
+    }
+
+    [Fact]
+    public void GenerateThumbnailFilename_Jpg()
+    {
+        Assert.Equal("screenshot_thumb.jpg", _service.GenerateThumbnailFilename("screenshot.jpg"));
+    }
+
+    [Fact]
+    public void GenerateThumbnailFilename_NoExtension()
+    {
+        Assert.Equal("noext_thumb", _service.GenerateThumbnailFilename("noext"));
+    }
+
+    [Fact]
+    public void GenerateThumbnailFilename_WithSubdirectory_StripsDirectory()
+    {
+        Assert.Equal("capture_001_thumb.png", _service.GenerateThumbnailFilename("subdir/capture_001.png"));
+    }
+
+    [Fact]
+    public void GetDirectoryPaths_ReturnCorrectPaths()
+    {
+        Assert.Equal(Path.Combine(_tempDir, "originals"), _service.GetOriginalsDir());
+        Assert.Equal(Path.Combine(_tempDir, "edited"), _service.GetEditedDir());
+        Assert.Equal(Path.Combine(_tempDir, "thumbnails"), _service.GetThumbnailsDir());
+        Assert.Equal(Path.Combine(_tempDir, "videos"), _service.GetVideosDir());
+    }
+}

--- a/src-dotnet/AmeCapture.Tests/Integration/TagRepositoryTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Integration/TagRepositoryTests.cs
@@ -1,0 +1,182 @@
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Domain.Entities;
+using AmeCapture.Infrastructure.Database;
+using AmeCapture.Infrastructure.Repositories;
+
+namespace AmeCapture.Tests.Integration;
+
+public class TagRepositoryTests : IAsyncLifetime
+{
+    private readonly string _dbPath;
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly TagRepository _repo;
+    private readonly WorkspaceRepository _workspaceRepo;
+
+    public TagRepositoryTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.db");
+        _connectionFactory = new SqliteConnectionFactory(_dbPath);
+        _repo = new TagRepository(_connectionFactory);
+        _workspaceRepo = new WorkspaceRepository(_connectionFactory);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await DatabaseInitializer.InitializeAsync(_connectionFactory);
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (File.Exists(_dbPath))
+            {
+                File.Delete(_dbPath);
+            }
+        }
+        catch
+        {
+        }
+        return Task.CompletedTask;
+    }
+
+    private async Task InsertWorkspaceItem(string id)
+    {
+        await _workspaceRepo.AddAsync(new WorkspaceItem
+        {
+            Id = id,
+            ItemType = WorkspaceItemType.Image,
+            OriginalPath = "/a.png",
+            CurrentPath = "/a.png",
+            Title = "test",
+            CreatedAt = "2026-01-01",
+            UpdatedAt = "2026-01-01"
+        });
+    }
+
+    [Fact]
+    public async Task AddAndGetAll_ReturnsTags()
+    {
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.AddAsync(new Tag { Id = "t2", Name = "tag2" });
+
+        var tags = await _repo.GetAllAsync();
+        Assert.Equal(2, tags.Count);
+        Assert.Equal("tag1", tags[0].Name);
+        Assert.Equal("tag2", tags[1].Name);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsTag()
+    {
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+
+        var found = await _repo.GetByIdAsync("t1");
+        Assert.NotNull(found);
+        Assert.Equal("tag1", found.Name);
+
+        Assert.Null(await _repo.GetByIdAsync("nonexistent"));
+    }
+
+    [Fact]
+    public async Task FindByName_ReturnsTag()
+    {
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+
+        var found = await _repo.FindByNameAsync("tag1");
+        Assert.NotNull(found);
+
+        Assert.Null(await _repo.FindByNameAsync("nonexistent"));
+    }
+
+    [Fact]
+    public async Task Delete_RemovesTag()
+    {
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.DeleteAsync("t1");
+        Assert.Null(await _repo.GetByIdAsync("t1"));
+    }
+
+    [Fact]
+    public async Task AddTagToItem_And_GetTagsForItem()
+    {
+        await InsertWorkspaceItem("w1");
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.AddAsync(new Tag { Id = "t2", Name = "tag2" });
+
+        await _repo.AddTagToItemAsync("w1", "t1");
+        await _repo.AddTagToItemAsync("w1", "t2");
+
+        var tags = await _repo.GetTagsForItemAsync("w1");
+        Assert.Equal(2, tags.Count);
+    }
+
+    [Fact]
+    public async Task RemoveTagFromItem()
+    {
+        await InsertWorkspaceItem("w1");
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.AddTagToItemAsync("w1", "t1");
+
+        Assert.Single(await _repo.GetTagsForItemAsync("w1"));
+
+        await _repo.RemoveTagFromItemAsync("w1", "t1");
+        Assert.Empty(await _repo.GetTagsForItemAsync("w1"));
+    }
+
+    [Fact]
+    public async Task SetTagsForItem_ReplacesExistingTags()
+    {
+        await InsertWorkspaceItem("w1");
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.AddAsync(new Tag { Id = "t2", Name = "tag2" });
+        await _repo.AddAsync(new Tag { Id = "t3", Name = "tag3" });
+
+        await _repo.SetTagsForItemAsync("w1", ["t1", "t2"]);
+        var tags = await _repo.GetTagsForItemAsync("w1");
+        Assert.Equal(2, tags.Count);
+
+        await _repo.SetTagsForItemAsync("w1", ["t3"]);
+        tags = await _repo.GetTagsForItemAsync("w1");
+        Assert.Single(tags);
+        Assert.Equal("tag3", tags[0].Name);
+    }
+
+    [Fact]
+    public async Task GetItemIdsByTag()
+    {
+        await InsertWorkspaceItem("w1");
+        await InsertWorkspaceItem("w2");
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.AddTagToItemAsync("w1", "t1");
+        await _repo.AddTagToItemAsync("w2", "t1");
+
+        var ids = await _repo.GetItemIdsByTagAsync("t1");
+        Assert.Equal(2, ids.Count);
+        Assert.Contains("w1", ids);
+        Assert.Contains("w2", ids);
+    }
+
+    [Fact]
+    public async Task GetAllTagsForItems()
+    {
+        await InsertWorkspaceItem("w1");
+        await InsertWorkspaceItem("w2");
+        await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
+        await _repo.AddAsync(new Tag { Id = "t2", Name = "tag2" });
+        await _repo.AddTagToItemAsync("w1", "t1");
+        await _repo.AddTagToItemAsync("w2", "t2");
+
+        var map = await _repo.GetAllTagsForItemsAsync(["w1", "w2"]);
+        Assert.Equal(2, map.Count);
+        Assert.Single(map["w1"]);
+        Assert.Single(map["w2"]);
+    }
+
+    [Fact]
+    public async Task GetAllTagsForItems_EmptyInput_ReturnsEmpty()
+    {
+        var map = await _repo.GetAllTagsForItemsAsync([]);
+        Assert.Empty(map);
+    }
+}

--- a/src-dotnet/AmeCapture.Tests/Integration/WorkspaceRepositoryTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Integration/WorkspaceRepositoryTests.cs
@@ -1,0 +1,189 @@
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Domain.Entities;
+using AmeCapture.Infrastructure.Database;
+using AmeCapture.Infrastructure.Repositories;
+
+namespace AmeCapture.Tests.Integration;
+
+public class WorkspaceRepositoryTests : IAsyncLifetime
+{
+    private readonly string _dbPath;
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly WorkspaceRepository _repo;
+
+    public WorkspaceRepositoryTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.db");
+        _connectionFactory = new SqliteConnectionFactory(_dbPath);
+        _repo = new WorkspaceRepository(_connectionFactory);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await DatabaseInitializer.InitializeAsync(_connectionFactory);
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (File.Exists(_dbPath))
+            {
+                File.Delete(_dbPath);
+            }
+        }
+        catch
+        {
+        }
+        return Task.CompletedTask;
+    }
+
+    private static WorkspaceItem CreateSampleItem(string id)
+    {
+        return new WorkspaceItem
+        {
+            Id = id,
+            ItemType = WorkspaceItemType.Image,
+            OriginalPath = "/original/test.png",
+            CurrentPath = "/current/test.png",
+            ThumbnailPath = "/thumb/test_thumb.png",
+            Title = "Test Item",
+            CreatedAt = "2026-01-01T00:00:00Z",
+            UpdatedAt = "2026-01-01T00:00:00Z",
+            IsFavorite = false,
+            MetadataJson = null
+        };
+    }
+
+    [Fact]
+    public async Task AddAndGetById_ReturnsItem()
+    {
+        var item = CreateSampleItem("id-1");
+        await _repo.AddAsync(item);
+
+        var found = await _repo.GetByIdAsync("id-1");
+
+        Assert.NotNull(found);
+        Assert.Equal("id-1", found.Id);
+        Assert.Equal("Test Item", found.Title);
+        Assert.Equal(WorkspaceItemType.Image, found.ItemType);
+        Assert.Equal("/original/test.png", found.OriginalPath);
+        Assert.Equal("/current/test.png", found.CurrentPath);
+        Assert.Equal("/thumb/test_thumb.png", found.ThumbnailPath);
+        Assert.False(found.IsFavorite);
+    }
+
+    [Fact]
+    public async Task GetById_NotFound_ReturnsNull()
+    {
+        var result = await _repo.GetByIdAsync("nonexistent");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAll_Empty_ReturnsEmptyList()
+    {
+        var items = await _repo.GetAllAsync();
+        Assert.Empty(items);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsMultipleItems()
+    {
+        await _repo.AddAsync(CreateSampleItem("id-1"));
+        await _repo.AddAsync(CreateSampleItem("id-2"));
+        await _repo.AddAsync(CreateSampleItem("id-3"));
+
+        var items = await _repo.GetAllAsync();
+        Assert.Equal(3, items.Count);
+    }
+
+    [Fact]
+    public async Task Update_ModifiesItem()
+    {
+        var item = CreateSampleItem("id-1");
+        await _repo.AddAsync(item);
+
+        item.Title = "Updated Title";
+        item.IsFavorite = true;
+        item.UpdatedAt = "2026-01-02T00:00:00Z";
+        await _repo.UpdateAsync(item);
+
+        var found = await _repo.GetByIdAsync("id-1");
+        Assert.NotNull(found);
+        Assert.Equal("Updated Title", found.Title);
+        Assert.True(found.IsFavorite);
+        Assert.Equal("2026-01-02T00:00:00Z", found.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesItem()
+    {
+        await _repo.AddAsync(CreateSampleItem("id-1"));
+        Assert.NotNull(await _repo.GetByIdAsync("id-1"));
+
+        await _repo.DeleteAsync("id-1");
+        Assert.Null(await _repo.GetByIdAsync("id-1"));
+    }
+
+    [Fact]
+    public async Task Delete_Nonexistent_IsOk()
+    {
+        await _repo.DeleteAsync("nonexistent");
+    }
+
+    [Fact]
+    public async Task VideoType_Roundtrips()
+    {
+        var item = CreateSampleItem("id-v1");
+        item.ItemType = WorkspaceItemType.Video;
+        await _repo.AddAsync(item);
+
+        var found = await _repo.GetByIdAsync("id-v1");
+        Assert.NotNull(found);
+        Assert.Equal(WorkspaceItemType.Video, found.ItemType);
+    }
+
+    [Fact]
+    public async Task NullOptionalFields_Roundtrip()
+    {
+        var item = new WorkspaceItem
+        {
+            Id = "id-opt",
+            ItemType = WorkspaceItemType.Image,
+            OriginalPath = "/original/test.png",
+            CurrentPath = "/current/test.png",
+            ThumbnailPath = null,
+            Title = "No Thumbnail",
+            CreatedAt = "2026-01-01T00:00:00Z",
+            UpdatedAt = "2026-01-01T00:00:00Z",
+            IsFavorite = false,
+            MetadataJson = null
+        };
+        await _repo.AddAsync(item);
+
+        var found = await _repo.GetByIdAsync("id-opt");
+        Assert.NotNull(found);
+        Assert.Null(found.ThumbnailPath);
+        Assert.Null(found.MetadataJson);
+    }
+
+    [Fact]
+    public async Task GetByIds_ReturnsMatchingItems()
+    {
+        await _repo.AddAsync(CreateSampleItem("id-1"));
+        await _repo.AddAsync(CreateSampleItem("id-2"));
+        await _repo.AddAsync(CreateSampleItem("id-3"));
+
+        var items = await _repo.GetByIdsAsync(["id-1", "id-3"]);
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.True(i.Id == "id-1" || i.Id == "id-3"));
+    }
+
+    [Fact]
+    public async Task GetByIds_Empty_ReturnsEmptyList()
+    {
+        var items = await _repo.GetByIdsAsync([]);
+        Assert.Empty(items);
+    }
+}


### PR DESCRIPTION
## Summary

- **Issue #178**: Implement SQLite-backed `WorkspaceRepository`, `TagRepository`, and `SettingsRepository` with full CRUD operations using `Microsoft.Data.Sqlite`
- **Issue #179**: Implement `StorageService` for managing originals/edited/thumbnails/videos directories with path resolution compatible with the existing Rust implementation
- **Issue #180**: Add comprehensive SQLite compatibility integration tests verifying schema creation, foreign key constraints, cascade deletes, and data roundtrip
- **Issue #181**: Update `AppSettings` DTO to match the Rust version (add `StartMinimized`, fix hotkey property naming to `HotkeyCaptureRegion`/`HotkeyCaptureFullscreen`/`HotkeyCaptureWindow`)

## Changes

### Domain Layer
- `AppSettings`: Added `StartMinimized`, renamed hotkey properties to match Rust
- `WorkspaceItem`: Changed `CreatedAt`/`UpdatedAt` from `DateTimeOffset` to `string` for exact SQLite compatibility

### Application Layer
- Added `IStorageService` interface for file storage path resolution
- Added `IDbConnectionFactory` interface for database connection abstraction
- Extended `ITagRepository` with missing methods (`GetByIdAsync`, `FindByNameAsync`, `AddTagToItemAsync`, `RemoveTagFromItemAsync`, `GetItemIdsByTagAsync`, `GetAllTagsForItemsAsync`)
- Extended `IWorkspaceRepository` with `GetByIdsAsync`

### Infrastructure Layer
- `SqliteConnectionFactory`: WAL journal mode, foreign keys enabled, connection pooling disabled
- `DatabaseInitializer`: Creates all tables and indexes matching Rust schema exactly
- `WorkspaceRepository`: Full SQLite implementation with `GetAll`, `GetById`, `Add`, `Update`, `Delete`, `GetByIds`
- `TagRepository`: Full SQLite implementation including tag-item associations with transactional `SetTagsForItem`
- `SettingsRepository`: Key-value store read/write matching Rust's `app_settings` table
- `StorageService`: Directory creation and path resolution for originals/edited/thumbnails/videos

### Tests
- 43 tests total (3 domain + 40 integration)
- `SqliteCompatibilityTests`: Schema validation, idempotent migrations, foreign key cascade delete, constraint enforcement
- `WorkspaceRepositoryTests`: 10 tests covering full CRUD, video type, null fields, batch lookup
- `TagRepositoryTests`: 10 tests covering CRUD, tag-item associations, batch operations
- `SettingsRepositoryTests`: 3 tests covering defaults, roundtrip, update
- `StorageServiceTests`: 11 tests covering directory creation, path resolution, thumbnail naming

Closes #178
Closes #179
Closes #180
Closes #181