### PR TITLE
feat: Phase 3 capture functionality (#182-#186)

### DIFF
--- a/documents/9. Windows API キャプチャ方式比較・選定.md
+++ b/documents/9. Windows API キャプチャ方式比較・選定.md
@@ -1,0 +1,96 @@
+# Windows API キャプチャ方式の比較・実装選定
+
+## 1. 比較対象
+
+| 方式                               | API 群                                                                          | 対応 OS              |
+| ---------------------------------- | ------------------------------------------------------------------------------- | -------------------- |
+| **GDI+ (BitBlt)**                  | `GetDC`, `CreateCompatibleDC`, `CreateCompatibleBitmap`, `BitBlt`               | Windows XP 以降      |
+| **Windows Graphics Capture API**   | `GraphicsCaptureItem`, `Direct3D11CaptureFramePool`, `Windows.Graphics.Capture` | Windows 10 1903 以降 |
+| **Desktop Duplication API (DXGI)** | `IDXGIOutputDuplication`                                                        | Windows 8 以降       |
+
+## 2. 特性比較
+
+### 2.1 パフォーマンス特性
+
+| 指標           | GDI+ (BitBlt)                      | Windows Graphics Capture     | Desktop Duplication (DXGI)   |
+| -------------- | ---------------------------------- | ---------------------------- | ---------------------------- |
+| **保存時間**   | 中程度（HBITMAP→PNG 変換）         | 高速（GPU フレーム直接取得） | 高速（GPU フレーム直接取得） |
+| **CPU 使用率** | 中〜高（CPU 側でビットマップ処理） | 低（GPU で処理）             | 低（GPU で処理）             |
+| **メモリ使用** | 中程度（システム RAM 上の DIB）    | 低（GPU テクスチャ）         | 低（GPU テクスチャ）         |
+| **対応解像度** | 任意                               | 任意                         | モニター出力に依存           |
+
+### 2.2 機能特性
+
+| 機能                                         | GDI+ (BitBlt)                       | Windows Graphics Capture        | Desktop Duplication (DXGI) |
+| -------------------------------------------- | ----------------------------------- | ------------------------------- | -------------------------- |
+| 全画面キャプチャ                             | ○                                   | ○                               | ○                          |
+| 領域指定キャプチャ                           | ○                                   | △（全体取得後にクロップ）       | △（全体取得後にクロップ）  |
+| ウィンドウ単位キャプチャ                     | ○                                   | ○                               | ×（モニター単位のみ）      |
+| ハードウェアアクセラレーション対応ウィンドウ | △（DWM の場合黒画面になる場合あり） | ○（確実に取得）                 | ○                          |
+| カーソル取得                                 | 別途描画必要                        | ○                               | ○                          |
+| .NET 相互運用の容易さ                        | 高（P/Invoke + System.Drawing）     | 低（WinRT、COM 相互運用が複雑） | 低（C++/COM 中心）         |
+
+### 2.3 開発・保守特性
+
+| 観点                     | GDI+ (BitBlt)                         | Windows Graphics Capture               | Desktop Duplication (DXGI)         |
+| ------------------------ | ------------------------------------- | -------------------------------------- | ---------------------------------- |
+| C# 実装の複雑さ          | 低（Win32 P/Invoke + System.Drawing） | 高（WinRT 投影、COM インターフェース） | 高（SlimDX/SharpDX/Vortice 必須）  |
+| NuGet 依存関係           | `System.Drawing.Common` のみ          | 特別なパッケージ不要（WinRT 投影）     | Vortice.Windows 等の外部ライブラリ |
+| 既存 Rust 実装との整合性 | 高（同じ GDI 手法）                   | 低（完全に別手法）                     | 低（完全に別手法）                 |
+| 最小対応 OS              | Windows XP                            | Windows 10 1903 (build 18362)          | Windows 8                          |
+
+## 3. 採用方式：GDI+ (BitBlt)
+
+### 3.1 選定根拠
+
+1. **既存 Rust 実装との整合性**
+   - `src-tauri/src/services/capture.rs` は GDI (`BitBlt`) を使用
+   - C# 移行で同じキャプチャ方式を採用することで、動作の一貫性を保証
+   - ピクセルフォーマット・色空間の差異によるデグレッドリスクを回避
+
+2. **C# 実装の簡潔性**
+   - `System.Drawing.Common` パッケージにより `Image.FromHbitmap()` で HBITMAP→`Bitmap` 変換が可能
+   - Rust 実装で必要だった `GetDIBits` による手動ピクセル抽出（BGRA→RGBA チャネルスワップ）が不要
+   - コード行数を大幅に削減しつつ、同等の機能を提供
+
+3. **依存関係の最小化**
+   - `System.Drawing.Common` のみで完結（DirectX/WinRT の複雑な COM 相互運用が不要）
+   - MAUI プロジェクトに追加のネイティブライブラリ参照が不要
+
+4. **クロスプラットフォーム考慮**
+   - MAUI は複数プラットフォームをターゲットとするが、キャプチャ機能は Windows 限定
+   - `[SupportedOSPlatform("windows")]` 属性で明示的にプラットフォーム制約を宣言
+   - DI コンテナで `#if WINDOWS` ガードにより非 Windows プラットフォームでのコンパイル安全性を確保
+
+### 3.2 実装の概要
+
+```
+CaptureService.CaptureFullScreenAsync()
+  ├── GetDC(NULL) → デスクトップ DC 取得
+  ├── CreateCompatibleDC → メモリ DC 作成
+  ├── CreateCompatibleBitmap → 互換ビットマップ作成
+  ├── BitBlt(SRCCOPY) → 画面内容をビットマップにコピー
+  ├── Image.FromHbitmap() → HBITMAP → System.Drawing.Bitmap
+  └── Bitmap.Save(path, PngFormat) → PNG ファイル保存
+
+CaptureService.CaptureWindowAsync(hwnd)
+  ├── GetWindowRect(hwnd) → ウィンドウ矩形取得
+  ├── DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) → 正確なウィンドウ境界取得
+  └── （以降は全画面と同じ GDI フロー）
+```
+
+### 3.3 既知の制限事項
+
+| 制限                                         | 影響                                 | 対応方針                                                           |
+| -------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------ |
+| ハードウェアアクセラレーション対象ウィンドウ | 一部アプリで黒画面になる可能性がある | Phase 4 以降で Windows Graphics Capture API へのフォールバック検討 |
+| DWM 有効時の透明度                           | Alpha チャネルが含まれない           | 不透明背景で描画するため実用上問題なし                             |
+| 高 DPI 環境                                  | DPI スケーリングの考慮が必要         | `SetProcessDPIAware` またはマニフェストで対応済み                  |
+
+## 4. 今後の改善候補
+
+Phase 4 以降で、Windows Graphics Capture API をフォールバックとして追加することで、以下の改善を図る：
+
+- DirectX フルスクリーンアプリケーションや HDR コンテンツのキャプチャ対応
+- カーソルオーバーレイの標準サポート
+- パフォーマンスの最適化（GPU 直接取得）

--- a/src-dotnet/AmeCapture.App/AmeCapture.App.csproj
+++ b/src-dotnet/AmeCapture.App/AmeCapture.App.csproj
@@ -66,6 +66,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 		<PackageReference Include="Serilog" Version="4.3.1" />

--- a/src-dotnet/AmeCapture.App/App.xaml.cs
+++ b/src-dotnet/AmeCapture.App/App.xaml.cs
@@ -1,16 +1,39 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Infrastructure.Database;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AmeCapture.App;
 
 public partial class App : global::Microsoft.Maui.Controls.Application
 {
-	public App()
-	{
-		InitializeComponent();
-	}
+    public App()
+    {
+        InitializeComponent();
+    }
 
-	protected override Window CreateWindow(IActivationState? activationState)
-	{
-		return new Window(new AppShell());
-	}
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        return new Window(new AppShell());
+    }
+
+    protected override async void OnStart()
+    {
+        base.OnStart();
+
+        try
+        {
+            var services = Handler?.MauiContext?.Services;
+            if (services == null) return;
+
+            var dbFactory = services.GetRequiredService<IDbConnectionFactory>();
+            await DatabaseInitializer.InitializeAsync(dbFactory);
+
+            var storageService = services.GetRequiredService<IStorageService>();
+            await storageService.EnsureDirectoriesAsync();
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Failed to initialize database or storage during startup");
+        }
+    }
 }

--- a/src-dotnet/AmeCapture.App/MauiProgram.cs
+++ b/src-dotnet/AmeCapture.App/MauiProgram.cs
@@ -1,3 +1,7 @@
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Infrastructure.Database;
+using AmeCapture.Infrastructure.Repositories;
+using AmeCapture.Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -50,6 +54,38 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
 
+        var basePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "AmeCapture",
+            "data");
+
+        var dbPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "AmeCapture",
+            "amecapture.db");
+
+        builder.Services.AddSingleton<IDbConnectionFactory>(_ =>
+        {
+            var dir = Path.GetDirectoryName(dbPath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            return new SqliteConnectionFactory(dbPath);
+        });
+
+        builder.Services.AddSingleton<IStorageService>(_ =>
+            new StorageService(basePath));
+
+        builder.Services.AddSingleton<IWorkspaceRepository, WorkspaceRepository>();
+        builder.Services.AddSingleton<ITagRepository, TagRepository>();
+        builder.Services.AddSingleton<ISettingsRepository, SettingsRepository>();
+
+#if WINDOWS
+        builder.Services.AddSingleton<ICaptureService, CaptureService>();
+        builder.Services.AddSingleton<IThumbnailService, ThumbnailService>();
+        builder.Services.AddSingleton<IWindowEnumerationService, WindowEnumerationService>();
+        builder.Services.AddSingleton<ICaptureOrchestrator, CaptureOrchestrator>();
+#endif
+
         builder.Services.AddTransient<ViewModels.WorkspaceViewModel>();
         builder.Services.AddTransient<Views.WorkspacePage>();
 
@@ -60,6 +96,12 @@ public static class MauiProgram
 #endif
 
         var app = builder.Build();
+
+        var dbFactory = app.Services.GetRequiredService<IDbConnectionFactory>();
+        DatabaseInitializer.InitializeAsync(dbFactory).GetAwaiter().GetResult();
+
+        var storageService = app.Services.GetRequiredService<IStorageService>();
+        storageService.EnsureDirectoriesAsync().GetAwaiter().GetResult();
 
         return app;
     }

--- a/src-dotnet/AmeCapture.App/MauiProgram.cs
+++ b/src-dotnet/AmeCapture.App/MauiProgram.cs
@@ -95,14 +95,6 @@ public static class MauiProgram
         builder.Logging.AddDebug();
 #endif
 
-        var app = builder.Build();
-
-        var dbFactory = app.Services.GetRequiredService<IDbConnectionFactory>();
-        DatabaseInitializer.InitializeAsync(dbFactory).GetAwaiter().GetResult();
-
-        var storageService = app.Services.GetRequiredService<IStorageService>();
-        storageService.EnsureDirectoriesAsync().GetAwaiter().GetResult();
-
-        return app;
+        return builder.Build();
     }
 }

--- a/src-dotnet/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
+++ b/src-dotnet/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
@@ -41,7 +41,6 @@ public partial class WorkspaceViewModel : ObservableObject
         Items.Clear();
         foreach (var item in items.OrderByDescending(i => i.CreatedAt))
             Items.Add(item);
-        OnPropertyChanged(nameof(Items));
     }
 
     [RelayCommand]
@@ -53,7 +52,6 @@ public partial class WorkspaceViewModel : ObservableObject
         {
             var item = await _captureOrchestrator.CaptureFullScreenAsync();
             Items.Insert(0, item);
-            OnPropertyChanged(nameof(Items));
         }
         finally
         {
@@ -70,7 +68,6 @@ public partial class WorkspaceViewModel : ObservableObject
             var item = await _captureOrchestrator.CaptureWindowAsync(hwnd);
             Items.Insert(0, item);
             IsWindowSelectionMode = false;
-            OnPropertyChanged(nameof(Items));
         }
         finally
         {
@@ -103,7 +100,6 @@ public partial class WorkspaceViewModel : ObservableObject
                 RegionCaptureInfo.TempPath, region);
             Items.Insert(0, item);
             RegionCaptureInfo = null;
-            OnPropertyChanged(nameof(Items));
         }
         finally
         {
@@ -130,7 +126,6 @@ public partial class WorkspaceViewModel : ObservableObject
             foreach (var w in windows)
                 Windows.Add(w);
             IsWindowSelectionMode = true;
-            OnPropertyChanged(nameof(Windows));
         }
         finally
         {

--- a/src-dotnet/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
+++ b/src-dotnet/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
@@ -1,14 +1,145 @@
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Application.Models;
+using AmeCapture.Domain.Entities;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace AmeCapture.App.ViewModels;
 
-public class WorkspaceViewModel : INotifyPropertyChanged
+public partial class WorkspaceViewModel : ObservableObject
 {
-    public event PropertyChangedEventHandler? PropertyChanged;
+    private readonly ICaptureOrchestrator? _captureOrchestrator;
+    private readonly IWorkspaceRepository? _workspaceRepository;
 
-    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    public ObservableCollection<WorkspaceItem> Items { get; } = [];
+    public ObservableCollection<WindowInfo> Windows { get; } = [];
+
+    [ObservableProperty]
+    public partial bool IsCapturing { get; set; }
+
+    [ObservableProperty]
+    public partial RegionCaptureInfo? RegionCaptureInfo { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsWindowSelectionMode { get; set; }
+
+    public WorkspaceViewModel() { }
+
+    public WorkspaceViewModel(
+        ICaptureOrchestrator? captureOrchestrator,
+        IWorkspaceRepository? workspaceRepository)
     {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        _captureOrchestrator = captureOrchestrator;
+        _workspaceRepository = workspaceRepository;
+    }
+
+    public async Task LoadItemsAsync()
+    {
+        if (_workspaceRepository == null) return;
+        var items = await _workspaceRepository.GetAllAsync();
+        Items.Clear();
+        foreach (var item in items.OrderByDescending(i => i.CreatedAt))
+            Items.Add(item);
+        OnPropertyChanged(nameof(Items));
+    }
+
+    [RelayCommand]
+    private async Task CaptureFullScreenAsync()
+    {
+        if (_captureOrchestrator == null) return;
+        IsCapturing = true;
+        try
+        {
+            var item = await _captureOrchestrator.CaptureFullScreenAsync();
+            Items.Insert(0, item);
+            OnPropertyChanged(nameof(Items));
+        }
+        finally
+        {
+            IsCapturing = false;
+        }
+    }
+
+    public async Task CaptureWindowAsync(nint hwnd)
+    {
+        if (_captureOrchestrator == null) return;
+        IsCapturing = true;
+        try
+        {
+            var item = await _captureOrchestrator.CaptureWindowAsync(hwnd);
+            Items.Insert(0, item);
+            IsWindowSelectionMode = false;
+            OnPropertyChanged(nameof(Items));
+        }
+        finally
+        {
+            IsCapturing = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task PrepareRegionCaptureAsync()
+    {
+        if (_captureOrchestrator == null) return;
+        IsCapturing = true;
+        try
+        {
+            RegionCaptureInfo = await _captureOrchestrator.PrepareRegionCaptureAsync();
+        }
+        finally
+        {
+            IsCapturing = false;
+        }
+    }
+
+    public async Task FinalizeRegionCaptureAsync(CaptureRegion region)
+    {
+        if (_captureOrchestrator == null || RegionCaptureInfo == null) return;
+        IsCapturing = true;
+        try
+        {
+            var item = await _captureOrchestrator.FinalizeRegionCaptureAsync(
+                RegionCaptureInfo.TempPath, region);
+            Items.Insert(0, item);
+            RegionCaptureInfo = null;
+            OnPropertyChanged(nameof(Items));
+        }
+        finally
+        {
+            IsCapturing = false;
+        }
+    }
+
+    public async Task CancelRegionCaptureAsync()
+    {
+        if (_captureOrchestrator == null || RegionCaptureInfo == null) return;
+        await _captureOrchestrator.CancelRegionCaptureAsync(RegionCaptureInfo.TempPath);
+        RegionCaptureInfo = null;
+    }
+
+    [RelayCommand]
+    private async Task PrepareWindowCaptureAsync()
+    {
+        if (_captureOrchestrator == null) return;
+        IsCapturing = true;
+        try
+        {
+            var windows = await _captureOrchestrator.PrepareWindowCaptureAsync();
+            Windows.Clear();
+            foreach (var w in windows)
+                Windows.Add(w);
+            IsWindowSelectionMode = true;
+            OnPropertyChanged(nameof(Windows));
+        }
+        finally
+        {
+            IsCapturing = false;
+        }
+    }
+
+    public void CancelWindowCapture()
+    {
+        IsWindowSelectionMode = false;
     }
 }

--- a/src-dotnet/AmeCapture.App/Views/WorkspacePage.xaml
+++ b/src-dotnet/AmeCapture.App/Views/WorkspacePage.xaml
@@ -2,31 +2,55 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodel="clr-namespace:AmeCapture.App.ViewModels"
+             xmlns:model="clr-namespace:AmeCapture.Domain.Entities;assembly=AmeCapture.Domain"
              x:Class="AmeCapture.App.Views.WorkspacePage"
              x:DataType="viewmodel:WorkspaceViewModel"
-             Title="Workspace">
+             Title="Workspace"
+             Loaded="OnPageLoaded">
 
-    <Grid RowDefinitions="Auto,*">
+    <Grid RowDefinitions="Auto,Auto,*">
         <HorizontalStackLayout Grid.Row="0" Padding="16,8" Spacing="12">
             <Label Text="AmeCapture"
                    FontSize="24"
                    FontAttributes="Bold"
                    VerticalOptions="Center" />
+            <Button Text="全画面"
+                    Command="{Binding CaptureFullScreenCommand}"
+                    SemanticProperties.Description="Capture full screen" />
+            <Button Text="領域"
+                    Command="{Binding PrepareRegionCaptureCommand}"
+                    SemanticProperties.Description="Capture region" />
+            <Button Text="ウィンドウ"
+                    Command="{Binding PrepareWindowCaptureCommand}"
+                    SemanticProperties.Description="Capture window" />
+            <ActivityIndicator IsRunning="{Binding IsCapturing}"
+                               IsVisible="{Binding IsCapturing}"
+                               WidthRequest="24" HeightRequest="24" />
         </HorizontalStackLayout>
 
-        <VerticalStackLayout Grid.Row="1"
-                             HorizontalOptions="Center"
-                             VerticalOptions="Center"
-                             Spacing="16">
-            <Label Text="No captures yet"
-                   FontSize="18"
-                   HorizontalOptions="Center"
-                   Opacity="0.5" />
-            <Label Text="Use a capture shortcut to get started"
-                   FontSize="14"
-                   HorizontalOptions="Center"
-                   Opacity="0.4" />
-        </VerticalStackLayout>
+        <CollectionView Grid.Row="2"
+                        ItemsSource="{Binding Items}"
+                        Margin="16,8"
+                        EmptyView="No captures yet. Use a capture shortcut to get started.">
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Orientation="Vertical" Span="4" HorizontalItemSpacing="12" VerticalItemSpacing="12" />
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="{x:Type model:WorkspaceItem}">
+                    <Border Padding="0" Margin="0" StrokeShape="RoundRectangle 8" HeightRequest="180" WidthRequest="180">
+                        <VerticalStackLayout>
+                            <Image Source="{Binding ThumbnailPath}"
+                                   Aspect="AspectFit"
+                                   HeightRequest="140" />
+                            <Label Text="{Binding Title}"
+                                   FontSize="12"
+                                   LineBreakMode="TailTruncation"
+                                   Margin="4,0" />
+                        </VerticalStackLayout>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
     </Grid>
 
 </ContentPage>

--- a/src-dotnet/AmeCapture.App/Views/WorkspacePage.xaml
+++ b/src-dotnet/AmeCapture.App/Views/WorkspacePage.xaml
@@ -8,7 +8,7 @@
              Title="Workspace"
              Loaded="OnPageLoaded">
 
-    <Grid RowDefinitions="Auto,Auto,*">
+    <Grid RowDefinitions="Auto,*">
         <HorizontalStackLayout Grid.Row="0" Padding="16,8" Spacing="12">
             <Label Text="AmeCapture"
                    FontSize="24"
@@ -28,7 +28,7 @@
                                WidthRequest="24" HeightRequest="24" />
         </HorizontalStackLayout>
 
-        <CollectionView Grid.Row="2"
+        <CollectionView Grid.Row="1"
                         ItemsSource="{Binding Items}"
                         Margin="16,8"
                         EmptyView="No captures yet. Use a capture shortcut to get started.">

--- a/src-dotnet/AmeCapture.App/Views/WorkspacePage.xaml.cs
+++ b/src-dotnet/AmeCapture.App/Views/WorkspacePage.xaml.cs
@@ -4,9 +4,17 @@ namespace AmeCapture.App.Views;
 
 public partial class WorkspacePage : ContentPage
 {
+    private readonly WorkspaceViewModel _viewModel;
+
     public WorkspacePage(WorkspaceViewModel viewModel)
     {
         InitializeComponent();
+        _viewModel = viewModel;
         BindingContext = viewModel;
+    }
+
+    private async void OnPageLoaded(object? sender, EventArgs e)
+    {
+        await _viewModel.LoadItemsAsync();
     }
 }

--- a/src-dotnet/AmeCapture.Application/Interfaces/ICaptureOrchestrator.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/ICaptureOrchestrator.cs
@@ -1,0 +1,14 @@
+using AmeCapture.Application.Models;
+using AmeCapture.Domain.Entities;
+
+namespace AmeCapture.Application.Interfaces;
+
+public interface ICaptureOrchestrator
+{
+    Task<WorkspaceItem> CaptureFullScreenAsync();
+    Task<WorkspaceItem> CaptureWindowAsync(nint hwnd);
+    Task<RegionCaptureInfo> PrepareRegionCaptureAsync();
+    Task<WorkspaceItem> FinalizeRegionCaptureAsync(string sourcePath, CaptureRegion region);
+    Task CancelRegionCaptureAsync(string sourcePath);
+    Task<IReadOnlyList<WindowInfo>> PrepareWindowCaptureAsync();
+}

--- a/src-dotnet/AmeCapture.Application/Interfaces/ICaptureService.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/ICaptureService.cs
@@ -1,0 +1,9 @@
+using AmeCapture.Application.Models;
+
+namespace AmeCapture.Application.Interfaces;
+
+public interface ICaptureService
+{
+    Task<CaptureResult> CaptureFullScreenAsync(string savePath);
+    Task<CaptureResult> CaptureWindowAsync(nint hwnd, string savePath);
+}

--- a/src-dotnet/AmeCapture.Application/Interfaces/IThumbnailService.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/IThumbnailService.cs
@@ -1,0 +1,6 @@
+namespace AmeCapture.Application.Interfaces;
+
+public interface IThumbnailService
+{
+    Task<string> GenerateThumbnailAsync(string sourcePath, string thumbnailPath);
+}

--- a/src-dotnet/AmeCapture.Application/Interfaces/IWindowEnumerationService.cs
+++ b/src-dotnet/AmeCapture.Application/Interfaces/IWindowEnumerationService.cs
@@ -1,0 +1,8 @@
+using AmeCapture.Application.Models;
+
+namespace AmeCapture.Application.Interfaces;
+
+public interface IWindowEnumerationService
+{
+    Task<IReadOnlyList<WindowInfo>> EnumerateWindowsAsync();
+}

--- a/src-dotnet/AmeCapture.Application/Models/CaptureRegion.cs
+++ b/src-dotnet/AmeCapture.Application/Models/CaptureRegion.cs
@@ -1,0 +1,9 @@
+namespace AmeCapture.Application.Models;
+
+public class CaptureRegion
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public uint Width { get; set; }
+    public uint Height { get; set; }
+}

--- a/src-dotnet/AmeCapture.Application/Models/CaptureResult.cs
+++ b/src-dotnet/AmeCapture.Application/Models/CaptureResult.cs
@@ -1,0 +1,8 @@
+namespace AmeCapture.Application.Models;
+
+public class CaptureResult
+{
+    public string FilePath { get; set; } = string.Empty;
+    public uint Width { get; set; }
+    public uint Height { get; set; }
+}

--- a/src-dotnet/AmeCapture.Application/Models/RegionCaptureInfo.cs
+++ b/src-dotnet/AmeCapture.Application/Models/RegionCaptureInfo.cs
@@ -1,0 +1,9 @@
+namespace AmeCapture.Application.Models;
+
+public class RegionCaptureInfo
+{
+    public string TempPath { get; set; } = string.Empty;
+    public uint ScreenWidth { get; set; }
+    public uint ScreenHeight { get; set; }
+    public string ImageDataUri { get; set; } = string.Empty;
+}

--- a/src-dotnet/AmeCapture.Application/Models/RegionCaptureInfo.cs
+++ b/src-dotnet/AmeCapture.Application/Models/RegionCaptureInfo.cs
@@ -5,5 +5,4 @@ public class RegionCaptureInfo
     public string TempPath { get; set; } = string.Empty;
     public uint ScreenWidth { get; set; }
     public uint ScreenHeight { get; set; }
-    public string ImageDataUri { get; set; } = string.Empty;
 }

--- a/src-dotnet/AmeCapture.Application/Models/WindowInfo.cs
+++ b/src-dotnet/AmeCapture.Application/Models/WindowInfo.cs
@@ -1,0 +1,9 @@
+namespace AmeCapture.Application.Models;
+
+public class WindowInfo
+{
+    public nint Hwnd { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string ClassName { get; set; } = string.Empty;
+    public (int X, int Y, int Width, int Height) Bounds { get; set; }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/AmeCapture.Infrastructure.csproj
+++ b/src-dotnet/AmeCapture.Infrastructure/AmeCapture.Infrastructure.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src-dotnet/AmeCapture.Infrastructure/Services/CaptureOrchestrator.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/CaptureOrchestrator.cs
@@ -32,7 +32,7 @@ public class CaptureOrchestrator : ICaptureOrchestrator
     {
         await _storageService.EnsureDirectoriesAsync();
 
-        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png";
         var originalPath = _storageService.ResolveOriginalPath(filename);
         var editedPath = _storageService.ResolveEditedPath(filename);
         var thumbPath = _storageService.ResolveThumbnailPath(filename);
@@ -64,7 +64,7 @@ public class CaptureOrchestrator : ICaptureOrchestrator
     {
         await _storageService.EnsureDirectoriesAsync();
 
-        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png";
         var originalPath = _storageService.ResolveOriginalPath(filename);
         var editedPath = _storageService.ResolveEditedPath(filename);
         var thumbPath = _storageService.ResolveThumbnailPath(filename);
@@ -98,16 +98,11 @@ public class CaptureOrchestrator : ICaptureOrchestrator
         var tempPath = Path.Combine(tempDir, $"amecapture_region_{Guid.NewGuid():N}.png");
         var captureResult = await _captureService.CaptureFullScreenAsync(tempPath);
 
-        var imageBytes = await File.ReadAllBytesAsync(tempPath);
-        var base64 = Convert.ToBase64String(imageBytes);
-        var imageDataUri = $"data:image/png;base64,{base64}";
-
         return new RegionCaptureInfo
         {
             TempPath = tempPath,
             ScreenWidth = captureResult.Width,
-            ScreenHeight = captureResult.Height,
-            ImageDataUri = imageDataUri
+            ScreenHeight = captureResult.Height
         };
     }
 
@@ -137,7 +132,7 @@ public class CaptureOrchestrator : ICaptureOrchestrator
         using var g = System.Drawing.Graphics.FromImage(cropped);
         g.DrawImage(img, 0, 0, new System.Drawing.Rectangle(x, y, w, h), System.Drawing.GraphicsUnit.Pixel);
 
-        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png";
         var originalPath = _storageService.ResolveOriginalPath(filename);
         var editedPath = _storageService.ResolveEditedPath(filename);
         var thumbPath = _storageService.ResolveThumbnailPath(filename);

--- a/src-dotnet/AmeCapture.Infrastructure/Services/CaptureOrchestrator.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/CaptureOrchestrator.cs
@@ -1,0 +1,206 @@
+using System.Runtime.Versioning;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Application.Models;
+using AmeCapture.Domain.Entities;
+
+namespace AmeCapture.Infrastructure.Services;
+
+[SupportedOSPlatform("windows")]
+public class CaptureOrchestrator : ICaptureOrchestrator
+{
+    private readonly ICaptureService _captureService;
+    private readonly IThumbnailService _thumbnailService;
+    private readonly IWindowEnumerationService _windowEnumerationService;
+    private readonly IStorageService _storageService;
+    private readonly IWorkspaceRepository _workspaceRepository;
+
+    public CaptureOrchestrator(
+        ICaptureService captureService,
+        IThumbnailService thumbnailService,
+        IWindowEnumerationService windowEnumerationService,
+        IStorageService storageService,
+        IWorkspaceRepository workspaceRepository)
+    {
+        _captureService = captureService;
+        _thumbnailService = thumbnailService;
+        _windowEnumerationService = windowEnumerationService;
+        _storageService = storageService;
+        _workspaceRepository = workspaceRepository;
+    }
+
+    public async Task<WorkspaceItem> CaptureFullScreenAsync()
+    {
+        await _storageService.EnsureDirectoriesAsync();
+
+        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+        var originalPath = _storageService.ResolveOriginalPath(filename);
+        var editedPath = _storageService.ResolveEditedPath(filename);
+        var thumbPath = _storageService.ResolveThumbnailPath(filename);
+
+        var captureResult = await _captureService.CaptureFullScreenAsync(originalPath);
+        File.Copy(originalPath, editedPath, overwrite: true);
+        await _thumbnailService.GenerateThumbnailAsync(originalPath, thumbPath);
+
+        var now = DateTime.UtcNow.ToString("o");
+        var item = new WorkspaceItem
+        {
+            Id = Guid.NewGuid().ToString(),
+            ItemType = WorkspaceItemType.Image,
+            OriginalPath = originalPath,
+            CurrentPath = editedPath,
+            ThumbnailPath = thumbPath,
+            Title = $"Capture {DateTime.Now:yyyy/MM/dd HH:mm:ss}",
+            CreatedAt = now,
+            UpdatedAt = now,
+            IsFavorite = false,
+            MetadataJson = null
+        };
+
+        await _workspaceRepository.AddAsync(item);
+        return item;
+    }
+
+    public async Task<WorkspaceItem> CaptureWindowAsync(nint hwnd)
+    {
+        await _storageService.EnsureDirectoriesAsync();
+
+        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+        var originalPath = _storageService.ResolveOriginalPath(filename);
+        var editedPath = _storageService.ResolveEditedPath(filename);
+        var thumbPath = _storageService.ResolveThumbnailPath(filename);
+
+        var captureResult = await _captureService.CaptureWindowAsync(hwnd, originalPath);
+        File.Copy(originalPath, editedPath, overwrite: true);
+        await _thumbnailService.GenerateThumbnailAsync(originalPath, thumbPath);
+
+        var now = DateTime.UtcNow.ToString("o");
+        var item = new WorkspaceItem
+        {
+            Id = Guid.NewGuid().ToString(),
+            ItemType = WorkspaceItemType.Image,
+            OriginalPath = originalPath,
+            CurrentPath = editedPath,
+            ThumbnailPath = thumbPath,
+            Title = $"Window Capture {DateTime.Now:yyyy/MM/dd HH:mm:ss}",
+            CreatedAt = now,
+            UpdatedAt = now,
+            IsFavorite = false,
+            MetadataJson = null
+        };
+
+        await _workspaceRepository.AddAsync(item);
+        return item;
+    }
+
+    public async Task<RegionCaptureInfo> PrepareRegionCaptureAsync()
+    {
+        var tempDir = Path.GetTempPath();
+        var tempPath = Path.Combine(tempDir, $"amecapture_region_{Guid.NewGuid():N}.png");
+        var captureResult = await _captureService.CaptureFullScreenAsync(tempPath);
+
+        var imageBytes = await File.ReadAllBytesAsync(tempPath);
+        var base64 = Convert.ToBase64String(imageBytes);
+        var imageDataUri = $"data:image/png;base64,{base64}";
+
+        return new RegionCaptureInfo
+        {
+            TempPath = tempPath,
+            ScreenWidth = captureResult.Width,
+            ScreenHeight = captureResult.Height,
+            ImageDataUri = imageDataUri
+        };
+    }
+
+    public async Task<WorkspaceItem> FinalizeRegionCaptureAsync(string sourcePath, CaptureRegion region)
+    {
+        ValidateTempPath(sourcePath);
+        await _storageService.EnsureDirectoriesAsync();
+
+        if (!File.Exists(sourcePath))
+            throw new FileNotFoundException("Source screenshot file not found.", sourcePath);
+
+        using var img = System.Drawing.Image.FromFile(sourcePath);
+        int x = Math.Max(0, Math.Min(region.X, img.Width - 1));
+        int y = Math.Max(0, Math.Min(region.Y, img.Height - 1));
+        int maxW = img.Width - x;
+        int maxH = img.Height - y;
+        int w = (int)Math.Min(region.Width, maxW);
+        int h = (int)Math.Min(region.Height, maxH);
+
+        if (w <= 0 || h <= 0)
+        {
+            TryDeleteFile(sourcePath);
+            throw new InvalidOperationException("Selected region is too small.");
+        }
+
+        using var cropped = new System.Drawing.Bitmap(w, h);
+        using var g = System.Drawing.Graphics.FromImage(cropped);
+        g.DrawImage(img, 0, 0, new System.Drawing.Rectangle(x, y, w, h), System.Drawing.GraphicsUnit.Pixel);
+
+        var filename = $"capture_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+        var originalPath = _storageService.ResolveOriginalPath(filename);
+        var editedPath = _storageService.ResolveEditedPath(filename);
+        var thumbPath = _storageService.ResolveThumbnailPath(filename);
+
+        cropped.Save(originalPath, System.Drawing.Imaging.ImageFormat.Png);
+        File.Copy(originalPath, editedPath, overwrite: true);
+        await _thumbnailService.GenerateThumbnailAsync(originalPath, thumbPath);
+
+        var now = DateTime.UtcNow.ToString("o");
+        var item = new WorkspaceItem
+        {
+            Id = Guid.NewGuid().ToString(),
+            ItemType = WorkspaceItemType.Image,
+            OriginalPath = originalPath,
+            CurrentPath = editedPath,
+            ThumbnailPath = thumbPath,
+            Title = $"Region Capture {DateTime.Now:yyyy/MM/dd HH:mm:ss}",
+            CreatedAt = now,
+            UpdatedAt = now,
+            IsFavorite = false,
+            MetadataJson = null
+        };
+
+        await _workspaceRepository.AddAsync(item);
+        TryDeleteFile(sourcePath);
+        return item;
+    }
+
+    public async Task CancelRegionCaptureAsync(string sourcePath)
+    {
+        try
+        {
+            ValidateTempPath(sourcePath);
+        }
+        catch
+        {
+            return;
+        }
+        TryDeleteFile(sourcePath);
+        await Task.CompletedTask;
+    }
+
+    public async Task<IReadOnlyList<WindowInfo>> PrepareWindowCaptureAsync()
+    {
+        return await _windowEnumerationService.EnumerateWindowsAsync();
+    }
+
+    private static void ValidateTempPath(string sourcePath)
+    {
+        var path = Path.GetFullPath(sourcePath);
+        var tempDir = Path.GetTempPath();
+
+        if (!path.StartsWith(tempDir, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Source path is outside the temp directory.");
+
+        var fileName = Path.GetFileName(path);
+        if (!fileName.StartsWith("amecapture_region_") || !fileName.EndsWith(".png"))
+            throw new InvalidOperationException("Invalid temp file name pattern.");
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch { }
+    }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Services/CaptureService.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/CaptureService.cs
@@ -1,0 +1,220 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Application.Models;
+
+namespace AmeCapture.Infrastructure.Services;
+
+[SupportedOSPlatform("windows")]
+public class CaptureService : ICaptureService
+{
+    public async Task<CaptureResult> CaptureFullScreenAsync(string savePath)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            throw new PlatformNotSupportedException("Screen capture is only supported on Windows.");
+
+        return await Task.Run(() =>
+        {
+            var dir = Path.GetDirectoryName(savePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            int width = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXSCREEN);
+            int height = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYSCREEN);
+
+            if (width <= 0 || height <= 0)
+                throw new InvalidOperationException("Invalid screen dimensions.");
+
+            using var screenDc = new SafeScreenDc(NativeMethods.GetDC(IntPtr.Zero));
+            using var memDc = new SafeCompatibleDc(screenDc);
+            using var bitmap = new SafeBitmap(memDc, width, height);
+            using var selectGuard = new SafeSelectObject(memDc, bitmap.DangerousGetHandle());
+
+            if (!NativeMethods.BitBlt(memDc, 0, 0, width, height, screenDc, 0, 0, NativeMethods.SRCCOPY))
+                throw new InvalidOperationException("BitBlt failed.");
+
+            using var img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+            img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
+
+            return new CaptureResult
+            {
+                FilePath = savePath,
+                Width = (uint)width,
+                Height = (uint)height
+            };
+        });
+    }
+
+    public async Task<CaptureResult> CaptureWindowAsync(nint hwnd, string savePath)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            throw new PlatformNotSupportedException("Window capture is only supported on Windows.");
+
+        return await Task.Run(() =>
+        {
+            var dir = Path.GetDirectoryName(savePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var (left, top, right, bottom) = GetWindowBounds(hwnd);
+            int width = right - left;
+            int height = bottom - top;
+
+            if (width <= 0 || height <= 0)
+                throw new InvalidOperationException("Invalid window dimensions.");
+
+            using var windowDc = new SafeWindowDc(hwnd, NativeMethods.GetWindowDC(hwnd));
+            using var memDc = new SafeCompatibleDc(windowDc);
+            using var bitmap = new SafeBitmap(memDc, width, height);
+            using var selectGuard = new SafeSelectObject(memDc, bitmap.DangerousGetHandle());
+
+            if (!NativeMethods.BitBlt(memDc, 0, 0, width, height, windowDc, 0, 0,
+                    NativeMethods.SRCCOPY | NativeMethods.CAPTUREBLT))
+                throw new InvalidOperationException("BitBlt failed.");
+
+            using var img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+            img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
+
+            return new CaptureResult
+            {
+                FilePath = savePath,
+                Width = (uint)width,
+                Height = (uint)height
+            };
+        });
+    }
+
+    private static (int Left, int Top, int Right, int Bottom) GetWindowBounds(nint hwnd)
+    {
+        var rect = new NativeMethods.RECT();
+        int hr = NativeMethods.DwmGetWindowAttribute(hwnd,
+            NativeMethods.DWMWA_EXTENDED_FRAME_BOUNDS,
+            ref rect, Marshal.SizeOf<NativeMethods.RECT>());
+        if (hr >= 0 && rect.Right > rect.Left && rect.Bottom > rect.Top)
+            return (rect.Left, rect.Top, rect.Right, rect.Bottom);
+
+        var fallback = new NativeMethods.RECT();
+        NativeMethods.GetWindowRect(hwnd, ref fallback);
+        return (fallback.Left, fallback.Top, fallback.Right, fallback.Bottom);
+    }
+}
+
+file static class NativeMethods
+{
+    public const int SM_CXSCREEN = 0;
+    public const int SM_CYSCREEN = 1;
+    public const int SRCCOPY = 0x00CC0020;
+    public const int CAPTUREBLT = 0x40000000;
+    public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    public static extern int GetSystemMetrics(int nIndex);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetWindowDC(IntPtr hWnd);
+
+    [DllImport("gdi32.dll")]
+    public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    public static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    public static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int nWidth, int nHeight);
+
+    [DllImport("gdi32.dll")]
+    public static extern bool DeleteObject(IntPtr ho);
+
+    [DllImport("gdi32.dll")]
+    public static extern IntPtr SelectObject(IntPtr hdc, IntPtr h);
+
+    [DllImport("gdi32.dll")]
+    public static extern bool BitBlt(IntPtr hdc, int x, int y, int w, int h,
+        IntPtr hdcSrc, int x1, int y1, int rop);
+
+    [DllImport("user32.dll")]
+    public static extern bool GetWindowRect(IntPtr hWnd, ref RECT rect);
+
+    [DllImport("dwmapi.dll")]
+    public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute,
+        ref RECT pvAttribute, int cbAttribute);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowText(IntPtr hWnd, char[] lpString, int nMaxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetClassName(IntPtr hWnd, char[] lpClassName, int nMaxCount);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsIconic(IntPtr hWnd);
+
+    public const int GWL_STYLE = -16;
+    public const long WS_DISABLED = 0x08000000L;
+
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+}
+
+file sealed class SafeScreenDc : SafeHandle
+{
+    private readonly IntPtr _dc;
+
+    public SafeScreenDc(IntPtr dc) : base(IntPtr.Zero, true) => _dc = dc;
+    public override bool IsInvalid => _dc == IntPtr.Zero;
+    public static implicit operator IntPtr(SafeScreenDc s) => s._dc;
+    protected override bool ReleaseHandle() => NativeMethods.ReleaseDC(IntPtr.Zero, _dc) != 0;
+}
+
+file sealed class SafeWindowDc : SafeHandle
+{
+    private readonly nint _hwnd;
+    private readonly IntPtr _dc;
+
+    public SafeWindowDc(nint hwnd, IntPtr dc) : base(IntPtr.Zero, true) { _hwnd = hwnd; _dc = dc; }
+    public override bool IsInvalid => _dc == IntPtr.Zero;
+    public static implicit operator IntPtr(SafeWindowDc s) => s._dc;
+    protected override bool ReleaseHandle() => NativeMethods.ReleaseDC(_hwnd, _dc) != 0;
+}
+
+file sealed class SafeCompatibleDc(IntPtr sourceDc) : SafeHandle(IntPtr.Zero, true)
+{
+    private readonly IntPtr _dc = NativeMethods.CreateCompatibleDC(sourceDc);
+    public override bool IsInvalid => _dc == IntPtr.Zero;
+    public static implicit operator IntPtr(SafeCompatibleDc s) => s._dc;
+    protected override bool ReleaseHandle() => NativeMethods.DeleteDC(_dc);
+}
+
+file sealed class SafeBitmap(IntPtr sourceDc, int w, int h) : SafeHandle(IntPtr.Zero, true)
+{
+    private readonly IntPtr _bmp = NativeMethods.CreateCompatibleBitmap(sourceDc, w, h);
+    public override bool IsInvalid => _bmp == IntPtr.Zero;
+    protected override bool ReleaseHandle() => NativeMethods.DeleteObject(_bmp);
+    public new IntPtr DangerousGetHandle() => _bmp;
+}
+
+file sealed class SafeSelectObject(IntPtr hdc, IntPtr bmpHandle) : SafeHandle(IntPtr.Zero, true)
+{
+    private readonly IntPtr _old = NativeMethods.SelectObject(hdc, bmpHandle);
+    public override bool IsInvalid => false;
+    protected override bool ReleaseHandle() { NativeMethods.SelectObject(hdc, _old); return true; }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Services/CaptureService.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/CaptureService.cs
@@ -177,44 +177,52 @@ file static class NativeMethods
 
 file sealed class SafeScreenDc : SafeHandle
 {
-    private readonly IntPtr _dc;
-
-    public SafeScreenDc(IntPtr dc) : base(IntPtr.Zero, true) => _dc = dc;
-    public override bool IsInvalid => _dc == IntPtr.Zero;
-    public static implicit operator IntPtr(SafeScreenDc s) => s._dc;
-    protected override bool ReleaseHandle() => NativeMethods.ReleaseDC(IntPtr.Zero, _dc) != 0;
+    public SafeScreenDc(IntPtr dc) : base(IntPtr.Zero, true) => SetHandle(dc);
+    public override bool IsInvalid => handle == IntPtr.Zero;
+    public static implicit operator IntPtr(SafeScreenDc s) => s.handle;
+    protected override bool ReleaseHandle() => NativeMethods.ReleaseDC(IntPtr.Zero, handle) != 0;
 }
 
 file sealed class SafeWindowDc : SafeHandle
 {
     private readonly nint _hwnd;
-    private readonly IntPtr _dc;
-
-    public SafeWindowDc(nint hwnd, IntPtr dc) : base(IntPtr.Zero, true) { _hwnd = hwnd; _dc = dc; }
-    public override bool IsInvalid => _dc == IntPtr.Zero;
-    public static implicit operator IntPtr(SafeWindowDc s) => s._dc;
-    protected override bool ReleaseHandle() => NativeMethods.ReleaseDC(_hwnd, _dc) != 0;
+    public SafeWindowDc(nint hwnd, IntPtr dc) : base(IntPtr.Zero, true) { _hwnd = hwnd; SetHandle(dc); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+    public static implicit operator IntPtr(SafeWindowDc s) => s.handle;
+    protected override bool ReleaseHandle() => NativeMethods.ReleaseDC(_hwnd, handle) != 0;
 }
 
-file sealed class SafeCompatibleDc(IntPtr sourceDc) : SafeHandle(IntPtr.Zero, true)
+file sealed class SafeCompatibleDc : SafeHandle
 {
-    private readonly IntPtr _dc = NativeMethods.CreateCompatibleDC(sourceDc);
-    public override bool IsInvalid => _dc == IntPtr.Zero;
-    public static implicit operator IntPtr(SafeCompatibleDc s) => s._dc;
-    protected override bool ReleaseHandle() => NativeMethods.DeleteDC(_dc);
+    public SafeCompatibleDc(IntPtr sourceDc) : base(IntPtr.Zero, true)
+    {
+        SetHandle(NativeMethods.CreateCompatibleDC(sourceDc));
+    }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+    public static implicit operator IntPtr(SafeCompatibleDc s) => s.handle;
+    protected override bool ReleaseHandle() => NativeMethods.DeleteDC(handle);
 }
 
-file sealed class SafeBitmap(IntPtr sourceDc, int w, int h) : SafeHandle(IntPtr.Zero, true)
+file sealed class SafeBitmap : SafeHandle
 {
-    private readonly IntPtr _bmp = NativeMethods.CreateCompatibleBitmap(sourceDc, w, h);
-    public override bool IsInvalid => _bmp == IntPtr.Zero;
-    protected override bool ReleaseHandle() => NativeMethods.DeleteObject(_bmp);
-    public new IntPtr DangerousGetHandle() => _bmp;
+    public SafeBitmap(IntPtr sourceDc, int w, int h) : base(IntPtr.Zero, true)
+    {
+        SetHandle(NativeMethods.CreateCompatibleBitmap(sourceDc, w, h));
+    }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+    protected override bool ReleaseHandle() => NativeMethods.DeleteObject(handle);
+    public new IntPtr DangerousGetHandle() => handle;
 }
 
-file sealed class SafeSelectObject(IntPtr hdc, IntPtr bmpHandle) : SafeHandle(IntPtr.Zero, true)
+file sealed class SafeSelectObject : SafeHandle
 {
-    private readonly IntPtr _old = NativeMethods.SelectObject(hdc, bmpHandle);
+    private readonly IntPtr _hdc;
+    private readonly IntPtr _old;
+    public SafeSelectObject(IntPtr hdc, IntPtr bmpHandle) : base(IntPtr.Zero, true)
+    {
+        _hdc = hdc;
+        _old = NativeMethods.SelectObject(hdc, bmpHandle);
+    }
     public override bool IsInvalid => false;
-    protected override bool ReleaseHandle() { NativeMethods.SelectObject(hdc, _old); return true; }
+    protected override bool ReleaseHandle() { NativeMethods.SelectObject(_hdc, _old); return true; }
 }

--- a/src-dotnet/AmeCapture.Infrastructure/Services/ThumbnailService.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/ThumbnailService.cs
@@ -1,0 +1,44 @@
+using System.Runtime.Versioning;
+using AmeCapture.Application.Interfaces;
+
+namespace AmeCapture.Infrastructure.Services;
+
+[SupportedOSPlatform("windows")]
+public class ThumbnailService : IThumbnailService
+{
+    public async Task<string> GenerateThumbnailAsync(string sourcePath, string thumbnailPath)
+    {
+        return await Task.Run(() =>
+        {
+            using var img = System.Drawing.Image.FromFile(sourcePath);
+
+            int maxDim = 256;
+            int thumbW, thumbH;
+            if (img.Width > img.Height)
+            {
+                thumbW = maxDim;
+                thumbH = (int)(img.Height * (double)maxDim / img.Width);
+            }
+            else
+            {
+                thumbH = maxDim;
+                thumbW = (int)(img.Width * (double)maxDim / img.Height);
+            }
+
+            if (thumbW <= 0) thumbW = 1;
+            if (thumbH <= 0) thumbH = 1;
+
+            using var thumb = new System.Drawing.Bitmap(thumbW, thumbH);
+            using var g = System.Drawing.Graphics.FromImage(thumb);
+            g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+            g.DrawImage(img, 0, 0, thumbW, thumbH);
+
+            var dir = Path.GetDirectoryName(thumbnailPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            thumb.Save(thumbnailPath, System.Drawing.Imaging.ImageFormat.Png);
+            return thumbnailPath;
+        });
+    }
+}

--- a/src-dotnet/AmeCapture.Infrastructure/Services/WindowEnumerationService.cs
+++ b/src-dotnet/AmeCapture.Infrastructure/Services/WindowEnumerationService.cs
@@ -1,0 +1,119 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using AmeCapture.Application.Interfaces;
+using AmeCapture.Application.Models;
+
+namespace AmeCapture.Infrastructure.Services;
+
+[SupportedOSPlatform("windows")]
+public class WindowEnumerationService : IWindowEnumerationService
+{
+    public async Task<IReadOnlyList<WindowInfo>> EnumerateWindowsAsync()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            throw new PlatformNotSupportedException("Window enumeration is only supported on Windows.");
+
+        return await Task.Run(() =>
+        {
+            var windows = new List<WindowInfo>();
+            var handle = GCHandle.Alloc(windows);
+            try
+            {
+                NativeMethods.EnumWindows((hwnd, lParam) =>
+                {
+                    if (!NativeMethods.IsWindowVisible(hwnd))
+                        return true;
+
+                    long style = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_STYLE);
+                    if ((style & NativeMethods.WS_DISABLED) != 0)
+                        return true;
+
+                    if (NativeMethods.IsIconic(hwnd))
+                        return true;
+
+                    var titleBuf = new char[512];
+                    int titleLen = NativeMethods.GetWindowText(hwnd, titleBuf, titleBuf.Length);
+                    if (titleLen == 0)
+                        return true;
+                    string title = new string(titleBuf, 0, titleLen);
+                    if (string.IsNullOrWhiteSpace(title))
+                        return true;
+
+                    var classBuf = new char[256];
+                    int classLen = NativeMethods.GetClassName(hwnd, classBuf, classBuf.Length);
+                    string className = new string(classBuf, 0, classLen);
+
+                    var rect = new NativeMethods.RECT();
+                    int hr = NativeMethods.DwmGetWindowAttribute(hwnd,
+                        NativeMethods.DWMWA_EXTENDED_FRAME_BOUNDS,
+                        ref rect, Marshal.SizeOf<NativeMethods.RECT>());
+
+                    (int x, int y, int w, int h) bounds;
+                    if (hr >= 0)
+                    {
+                        bounds = (rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
+                    }
+                    else
+                    {
+                        var fallback = new NativeMethods.RECT();
+                        NativeMethods.GetWindowRect(hwnd, ref fallback);
+                        bounds = (fallback.Left, fallback.Top, fallback.Right - fallback.Left, fallback.Bottom - fallback.Top);
+                    }
+
+                    var list = (List<WindowInfo>)GCHandle.FromIntPtr(lParam).Target!;
+                    list.Add(new WindowInfo
+                    {
+                        Hwnd = hwnd,
+                        Title = title,
+                        ClassName = className,
+                        Bounds = bounds
+                    });
+                    return true;
+                }, GCHandle.ToIntPtr(handle));
+            }
+            finally
+            {
+                handle.Free();
+            }
+
+            windows.Sort((a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase));
+            return windows;
+        });
+    }
+}
+
+file static class NativeMethods
+{
+    public const int GWL_STYLE = -16;
+    public const long WS_DISABLED = 0x08000000L;
+    public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left, Top, Right, Bottom; }
+
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowText(IntPtr hWnd, char[] lpString, int nMaxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetClassName(IntPtr hWnd, char[] lpClassName, int nMaxCount);
+
+    [DllImport("dwmapi.dll")]
+    public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, ref RECT pvAttribute, int cbAttribute);
+
+    [DllImport("user32.dll")]
+    public static extern bool GetWindowRect(IntPtr hWnd, ref RECT rect);
+}

--- a/src-dotnet/AmeCapture.Tests/Domain/CaptureModelTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Domain/CaptureModelTests.cs
@@ -50,6 +50,5 @@ public class CaptureModelTests
         Assert.Equal(string.Empty, info.TempPath);
         Assert.Equal(0u, info.ScreenWidth);
         Assert.Equal(0u, info.ScreenHeight);
-        Assert.Equal(string.Empty, info.ImageDataUri);
     }
 }

--- a/src-dotnet/AmeCapture.Tests/Domain/CaptureModelTests.cs
+++ b/src-dotnet/AmeCapture.Tests/Domain/CaptureModelTests.cs
@@ -1,0 +1,55 @@
+using AmeCapture.Application.Models;
+
+namespace AmeCapture.Tests.Domain;
+
+public class CaptureModelTests
+{
+    [Fact]
+    public void CaptureRegion_DefaultValues()
+    {
+        var region = new CaptureRegion();
+        Assert.Equal(0, region.X);
+        Assert.Equal(0, region.Y);
+        Assert.Equal(0u, region.Width);
+        Assert.Equal(0u, region.Height);
+    }
+
+    [Fact]
+    public void CaptureRegion_SetValues()
+    {
+        var region = new CaptureRegion { X = 10, Y = 20, Width = 100, Height = 200 };
+        Assert.Equal(10, region.X);
+        Assert.Equal(20, region.Y);
+        Assert.Equal(100u, region.Width);
+        Assert.Equal(200u, region.Height);
+    }
+
+    [Fact]
+    public void WindowInfo_DefaultValues()
+    {
+        var info = new WindowInfo();
+        Assert.Equal(IntPtr.Zero, info.Hwnd);
+        Assert.Equal(string.Empty, info.Title);
+        Assert.Equal(string.Empty, info.ClassName);
+        Assert.Equal(default, info.Bounds);
+    }
+
+    [Fact]
+    public void CaptureResult_DefaultValues()
+    {
+        var result = new CaptureResult();
+        Assert.Equal(string.Empty, result.FilePath);
+        Assert.Equal(0u, result.Width);
+        Assert.Equal(0u, result.Height);
+    }
+
+    [Fact]
+    public void RegionCaptureInfo_DefaultValues()
+    {
+        var info = new RegionCaptureInfo();
+        Assert.Equal(string.Empty, info.TempPath);
+        Assert.Equal(0u, info.ScreenWidth);
+        Assert.Equal(0u, info.ScreenHeight);
+        Assert.Equal(string.Empty, info.ImageDataUri);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement full screen capture, region capture, and window capture services using GDI+ (BitBlt) via `System.Drawing.Common` and Win32 P/Invoke
- Add `CaptureService`, `ThumbnailService`, `WindowEnumerationService`, and `CaptureOrchestrator` in Infrastructure layer
- Wire up DI registration in `MauiProgram.cs` with `#if WINDOWS` platform guards
- Update `WorkspaceViewModel` with CommunityToolkit.Mvvm `[RelayCommand]` for XAML binding
- Update `WorkspacePage.xaml` with capture buttons, thumbnail grid (CollectionView), and `Border` (replacing obsolete `Frame`)
- Document GDI+ vs Windows Graphics Capture API comparison and selection rationale

Closes #182
Closes #183
Closes #184
Closes #185
Closes #186

## Test plan

- [x] 48 C# unit tests pass (43 existing + 5 new CaptureModel tests)
- [x] `npm run check:all` passes (tsc, eslint, clippy, prettier)
- [x] MAUI App builds with 0 errors, 0 warnings on Windows target
- [x] Infrastructure project builds with 0 errors