### PR TITLE
feat: Phase 6 - MAUI をプライマリ実装に昇格、従来 Tauri/Rust 実装を凍結 (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ AmeCapture/
 
 ### Primary (.NET MAUI)
 
-- **.NET 10** with **MAUI**
+- **.NET 10** with **MAUI** (Preview — 正式リリース後に安定版へ移行予定)
 - **CommunityToolkit.Mvvm** for MVVM pattern
 - **SkiaSharp** for image annotation rendering
 - **Microsoft.Data.Sqlite** for SQLite database

--- a/README.md
+++ b/README.md
@@ -1,116 +1,98 @@
 # AmeCapture
 
-A local screen capture application built with **Rust + Tauri v2** and **React + TypeScript**.
+A local screen capture application built with **.NET MAUI (C#)** and **SkiaSharp** for image editing.
 
 ## Architecture
 
 ```text
 AmeCapture/
-├── src/                        # Frontend (React + TypeScript)
-│   ├── main.tsx               # Entry point
-│   ├── App.tsx                # Root component
-│   ├── pages/                 # Page components
-│   │   ├── WorkspacePage.tsx  # Capture history browser
-│   │   ├── EditorPage.tsx     # Image annotation editor
-│   │   └── SettingsPage.tsx   # Application settings
-│   ├── components/            # Reusable UI components
-│   │   ├── ThumbnailGrid.tsx  # Image thumbnail grid
-│   │   ├── Toolbar.tsx        # Main toolbar
-│   │   ├── SearchBar.tsx      # Search/filter bar
-│   │   └── DetailPanel.tsx    # Item detail panel
-│   ├── stores/                # Zustand state stores
-│   ├── hooks/                 # Custom React hooks
-│   ├── types/                 # TypeScript type definitions
-│   └── lib/                   # Utility functions
-├── src-tauri/                  # Backend (Rust + Tauri v2)
-│   ├── src/
-│   │   ├── main.rs            # Rust entry point
-│   │   ├── lib.rs             # Tauri app setup & plugin registration
-│   │   ├── commands/          # Tauri IPC command handlers
-│   │   │   ├── capture.rs     # Capture commands
-│   │   │   ├── workspace.rs   # Workspace CRUD commands
-│   │   │   ├── editor.rs      # Editor commands
-│   │   │   └── settings.rs    # Settings commands
-│   │   ├── capture/           # Screen capture logic (Win32 API)
-│   │   ├── workspace/         # Workspace item management
-│   │   ├── editor/            # Image editing tools
-│   │   ├── db/                # SQLite database (rusqlite)
-│   │   ├── config/            # App configuration
-│   │   └── utils/             # Error types & utilities
-│   ├── Cargo.toml             # Rust dependencies
-│   └── tauri.conf.json        # Tauri configuration
-├── package.json                # Node.js dependencies
-├── vite.config.ts              # Vite build config
-└── tsconfig.json               # TypeScript config
+├── src-dotnet/                          # .NET MAUI Application (primary)
+│   ├── AmeCapture.Domain/               # Domain entities (no dependencies)
+│   │   └── Entities/
+│   │       ├── WorkspaceItem.cs         # Capture item model
+│   │       ├── Tag.cs                   # Tag model
+│   │       ├── AppSettings.cs           # App settings
+│   │       └── Annotation.cs           # Annotation hierarchy
+│   ├── AmeCapture.Application/          # Interfaces & Models
+│   │   ├── Interfaces/                  # Service contracts
+│   │   ├── Models/                      # DTOs (CaptureResult, WindowInfo, etc.)
+│   │   └── Messages/                    # Messenger messages
+│   ├── AmeCapture.Infrastructure/       # Implementations (Windows)
+│   │   ├── Database/                    # SQLite (Microsoft.Data.Sqlite)
+│   │   ├── Repositories/                # Data access
+│   │   └── Services/                    # Capture, Editor, Tray, Shortcuts, etc.
+│   ├── AmeCapture.App/                  # MAUI UI Layer
+│   │   ├── Views/                       # XAML pages
+│   │   ├── ViewModels/                  # MVVM ViewModels
+│   │   └── Platforms/                   # Platform-specific code
+│   └── AmeCapture.Tests/                # xUnit tests
+├── src-tauri/                           # [FROZEN] Legacy Rust + Tauri v2 (deprecated)
+├── src/                                 # [FROZEN] Legacy React + TypeScript frontend (deprecated)
+├── documents/                           # Design & migration documents
+└── scripts/                             # Build utilities
 ```
 
 ## Tech Stack
 
-### Frontend
+### Primary (.NET MAUI)
 
-- **React 19** + **TypeScript 5.8**
-- **Tailwind CSS 4** for styling
-- **Zustand** for state management
-- **Lucide React** for icons
-- **Vite 6** for build tooling
+- **.NET 10** with **MAUI**
+- **CommunityToolkit.Mvvm** for MVVM pattern
+- **SkiaSharp** for image annotation rendering
+- **Microsoft.Data.Sqlite** for SQLite database
+- **Serilog** for structured logging
+- **Win32 API** (P/Invoke) for screen capture (GDI+ BitBlt)
 
-### Backend
+### Legacy (Frozen)
 
-- **Rust** (Edition 2021)
-- **Tauri v2** for desktop app framework
-- **rusqlite** for SQLite database
-- **image** crate for image processing
-- **Win32 API** (via `windows` crate) for screen capture
-
-### Plugins
-
-- `tauri-plugin-clipboard-manager` - Clipboard operations
-- `tauri-plugin-global-shortcut` - Global hotkeys
-- `tauri-plugin-notification` - System notifications
-- `tauri-plugin-store` - Persistent key-value store
+- **Rust** + **Tauri v2** (backend) — see `src-tauri/`
+- **React 19** + **TypeScript 5.8** (frontend) — see `src/`
 
 ## Getting Started
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18+)
-- [Rust](https://www.rust-lang.org/tools/install) (v1.70+)
-- [Tauri Prerequisites](https://v2.tauri.app/start/prerequisites/)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (latest preview)
+- **Windows 10 1809+** (for Win32 platform features)
+- Visual Studio 2022 17.12+ or later with MAUI workload
 
-### Install Dependencies
+### Build & Run
 
 ```bash
-# Install frontend dependencies
-npm install
+# Build the .NET MAUI application
+dotnet build src-dotnet/AmeCapture.App/AmeCapture.App.csproj -f net10.0-windows10.0.19041.0
 
-# Build Rust dependencies (first time takes a while)
-cd src-tauri && cargo build
+# Run the application
+dotnet run --project src-dotnet/AmeCapture.App/AmeCapture.App.csproj -f net10.0-windows10.0.19041.0
 ```
 
-### Development
+### Run Tests
 
 ```bash
-# Start dev server (frontend + backend with hot reload)
+dotnet test src-dotnet/AmeCapture.Tests/
+```
+
+### Legacy (Tauri/Rust)
+
+The legacy Tauri/Rust application is frozen. See [Migration Guide](documents/MigrationGuide.md) for details.
+
+```bash
+# Legacy dev server (requires Node.js + Rust)
 npm run tauri dev
 ```
 
-### Build
+## Features
 
-```bash
-# Build production app
-npm run tauri build
-```
-
-## Features (MVP)
-
-- [x] Full screen capture
+- [x] Full screen capture (GDI+ BitBlt)
 - [x] Region capture
 - [x] Window capture
 - [x] Capture history (workspace)
-- [x] Image annotation (arrow, rectangle, mosaic)
+- [x] Image annotation (arrow, rectangle, text, mosaic, crop)
 - [x] Undo/Redo
 - [x] Global hotkeys
 - [x] Clipboard copy
+- [x] System tray with minimize-to-tray
+- [x] Tag management
 - [x] Settings management
 
 ## License

--- a/documents/MigrationGuide.md
+++ b/documents/MigrationGuide.md
@@ -1,0 +1,179 @@
+# AmeCapture 移行ガイド — Tauri/Rust 版から .NET MAUI 版へ
+
+## 1. 概要
+
+本ドキュメントは、AmeCapture を Tauri/Rust 版から .NET MAUI 版へ移行するための手順書です。両バージョン間のデータ互換性について説明し、設定移行およびロールバック手順を記載します。
+
+## 2. データ互換方針
+
+### 2.1 自動互換（ユーザー操作不要）
+
+| 項目                       | 方針     | 詳細                                                                                 |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| **SQLite スキーマ**        | 完全互換 | 同一 `CREATE TABLE IF NOT EXISTS` 定義。両バージョンで同じテーブル・インデックス構成 |
+| **PRAGMA 設定**            | 完全互換 | `journal_mode=WAL`, `foreign_keys=ON` を両バージョンで使用                           |
+| **画像ファイル形式**       | 完全互換 | PNG/JPG 形式は変更なし                                                               |
+| **サムネイル命名規則**     | 完全互換 | `{name}_thumb.{ext}` 形式を両バージョンで使用                                        |
+| **ファイルストレージ構造** | 完全互換 | `originals/`, `edited/`, `thumbnails/`, `videos/` の構成を維持                       |
+| **アプリ識別子**           | 同一     | `com.amecapture.app`                                                                 |
+
+### 2.2 手動対応が必要な項目
+
+| 項目                   | 説明                                      | 対応方法                           |
+| ---------------------- | ----------------------------------------- | ---------------------------------- |
+| **データベースのパス** | 旧版と新版で DB ファイル位置が異なる      | 手動コピーまたはシンボリックリンク |
+| **設定データ**         | 旧版は JSON ファイル + DB、新版は DB のみ | 手動移行（下記手順参照）           |
+| **ログファイル**       | フォーマット・パスが変更                  | 移行不要（旧ログは残置）           |
+
+### 2.3 非互換（仕様変更）
+
+| 項目             | 旧版 (Tauri)             | 新版 (MAUI)                   |
+| ---------------- | ------------------------ | ----------------------------- |
+| ログフォーマット | tracing 構造化ログ       | Serilog テキスト形式          |
+| アーキテクチャ   | マルチプロセス (WebView) | シングルプロセス (ネイティブ) |
+
+## 3. データ保存場所
+
+### 3.1 旧版 (Tauri/Rust) のパス
+
+| データ         | パス                                            |
+| -------------- | ----------------------------------------------- |
+| データベース   | `%APPDATA%\com.amecapture.app\amecapture.db`    |
+| 設定ファイル   | `%APPDATA%\com.amecapture.app\appsettings.json` |
+| ログ           | `%APPDATA%\com.amecapture.app\logs\`            |
+| キャプチャ画像 | `%USERPROFILE%\Pictures\AmeCapture\` (既定)     |
+
+### 3.2 新版 (.NET MAUI) のパス
+
+| データ       | パス                                             |
+| ------------ | ------------------------------------------------ |
+| データベース | `%LOCALAPPDATA%\AmeCapture\amecapture.db`        |
+| ストレージ   | `%LOCALAPPDATA%\AmeCapture\data\`                |
+| ログ         | `%LOCALAPPDATA%\AmeCapture\logs\amecapture-.log` |
+
+## 4. 設定移行手順
+
+### 4.1 旧版の設定を確認
+
+旧版の設定は以下のいずれかに保存されています:
+
+1. **appsettings.json**（ファイルベース）
+   - 場所: `%APPDATA%\com.amecapture.app\appsettings.json`
+   - 形式: JSON (`camelCase` キー)
+
+2. **app_settings テーブル**（DB ベース）
+   - 場所: `%APPDATA%\com.amecapture.app\amecapture.db`
+   - キー: `save_path`, `image_format`, `start_minimized`, `hotkey_capture_region`, `hotkey_capture_fullscreen`, `hotkey_capture_window`
+
+### 4.2 新版へのデータベース移行
+
+新版と旧版は同じ SQLite スキーマを使用しています。旧版のデータベースを新版の場所にコピーすることで、すべてのキャプチャ履歴・タグ・設定を移行できます。
+
+#### 手順
+
+```powershell
+# 1. 新版のデータディレクトリを作成
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\AmeCapture"
+
+# 2. 旧版のデータベースをコピー
+Copy-Item "$env:APPDATA\com.amecapture.app\amecapture.db" "$env:LOCALAPPDATA\AmeCapture\amecapture.db"
+
+# 3. （オプション）旧版のキャプチャ画像の保存先が既定以外の場合、
+#    新版の設定で保存先を変更するか、データを新しい場所にコピー
+```
+
+### 4.3 設定の個別移行（データベースコピーをしない場合）
+
+1. 新版 AmeCapture を起動（自動的に DB とディレクトリが作成される）
+2. 新版の設定画面で以下を旧版と同じ値に設定:
+
+| 設定項目             | 旧版のキー                  | 新版の項目 | 既定値                           |
+| -------------------- | --------------------------- | ---------- | -------------------------------- |
+| 保存先パス           | `save_path`                 | 保存先     | `%LOCALAPPDATA%\AmeCapture\data` |
+| 画像形式             | `image_format`              | 画像形式   | `png`                            |
+| 範囲キャプチャ       | `hotkey_capture_region`     | ホットキー | `Ctrl+Shift+S`                   |
+| 全画面キャプチャ     | `hotkey_capture_fullscreen` | ホットキー | `Ctrl+Shift+F`                   |
+| ウィンドウキャプチャ | `hotkey_capture_window`     | ホットキー | `Ctrl+Shift+W`                   |
+
+### 4.4 キャプチャ画像の移行
+
+旧版のキャプチャ画像を新版のストレージに移行する場合:
+
+```powershell
+# 新版のストレージディレクトリ構造を確認
+# originals/, edited/, thumbnails/, videos/ が作成される
+
+# 旧版のキャプチャ画像を新版にコピー（保存先が異なる場合）
+# 例: 旧版の保存先が Pictures\AmeCapture の場合
+Copy-Item -Recurse "$env:USERPROFILE\Pictures\AmeCapture\originals\*" "$env:LOCALAPPDATA\AmeCapture\data\originals\"
+Copy-Item -Recurse "$env:USERPROFILE\Pictures\AmeCapture\edited\*" "$env:LOCALAPPDATA\AmeCapture\data\edited\"
+Copy-Item -Recurse "$env:USERPROFILE\Pictures\AmeCapture\thumbnails\*" "$env:LOCALAPPDATA\AmeCapture\data\thumbnails\"
+```
+
+**注意**: データベースをコピーした場合、`workspace_items` テーブルの `original_path`, `current_path`, `thumbnail_path` は旧パスのままです。新しいストレージにファイルを移動した場合は、DB 内のパスも更新する必要があります。ファイルを元の場所に残すか、新しい場所にコピーして DB のパスを更新してください。
+
+## 5. ロールバック手順
+
+新版から旧版に戻す必要がある場合の手順です。
+
+### 5.1 旧版へのロールバック
+
+```powershell
+# 1. 新版 AmeCapture を終了
+
+# 2. 新版のデータをバックアップ
+Compress-Archive -Path "$env:LOCALAPPDATA\AmeCapture" -DestinationPath "$env:USERPROFILE\Desktop\AmeCapture_MAUI_backup.zip"
+
+# 3. 旧版 (Tauri) をインストール・起動
+# 旧版は独自のデータディレクトリ (%APPDATA%\com.amecapture.app\) を使用するため、
+# 新版で作成されたデータは影響を受けません
+
+# 4. 旧版でキャプチャしたデータはそのまま旧版の DB に残っています
+```
+
+### 5.2 データベースのロールバック
+
+新版で作成されたキャプチャデータを旧版に戻す場合:
+
+1. 新版の DB (`%LOCALAPPDATA%\AmeCapture\amecapture.db`) を SQLite ツールで開く
+2. 新版で追加されたレコードをエクスポート（SQL 形式）
+3. 旧版の DB (`%APPDATA%\com.amecapture.app\amecapture.db`) にインポート
+4. ファイルパスが異なる場合は、`workspace_items` テーブルのパス列を更新
+
+### 5.3 並行稼働
+
+旧版と新版は**異なるデータディレクトリ**を使用するため、一時的に両方をインストールして並行稼働が可能です。ただし、同じ SQLite ファイルを同時に開くことは推奨されません（WAL ロックの競合）。
+
+## 6. 移行後の確認項目
+
+- [ ] 新版が正常に起動すること
+- [ ] キャプチャ履歴が表示されること（DB 移行時）
+- [ ] ホットキーが正常に動作すること
+- [ ] システムトレイに常駐すること
+- [ ] 各種キャプチャ（全画面/範囲/ウィンドウ）が動作すること
+- [ ] クリップボードへのコピーが動作すること
+- [ ] 画像編集が動作すること
+- [ ] タグ管理が動作すること
+
+## 7. 旧版のアンインストール
+
+移行が完了し、旧版が不要になった場合:
+
+1. 旧版 AmeCapture (Tauri) をアンインストール
+2. 旧版のデータをバックアップ後に削除（オプション）:
+
+```powershell
+# バックアップ
+Compress-Archive -Path "$env:APPDATA\com.amecapture.app" -DestinationPath "$env:USERPROFILE\Desktop\AmeCapture_Tauri_backup.zip"
+
+# 削除（バックアップ後に実行）
+Remove-Item -Recurse -Force "$env:APPDATA\com.amecapture.app"
+```
+
+3. 旧版のキャプチャ画像（`Pictures\AmeCapture\` など）は必要に応じて残置または削除
+
+## 8. 参考ドキュメント
+
+- [DB スキーマ解析と C# 移行互換方針](5.%20DB%E3%82%B9%E3%82%AD%E3%83%BC%E3%83%9E%E8%A7%A3%E6%9E%90%E3%81%A8C%23%E7%A7%BB%E8%A1%8C%E4%BA%92%E6%8F%9B%E6%96%B9%E9%87%9D.md)
+- [リリースノート](ReleaseNotes.md)
+- [旧版の凍結に関する通知](../src-tauri/FROZEN.md)

--- a/documents/MigrationGuide.md
+++ b/documents/MigrationGuide.md
@@ -100,10 +100,13 @@ Copy-Item "$env:APPDATA\com.amecapture.app\amecapture.db" "$env:LOCALAPPDATA\Ame
 旧版のキャプチャ画像を新版のストレージに移行する場合:
 
 ```powershell
-# 新版のストレージディレクトリ構造を確認
-# originals/, edited/, thumbnails/, videos/ が作成される
+# 1. 新版のストレージディレクトリを作成（存在しない場合）
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\AmeCapture\data\originals"
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\AmeCapture\data\edited"
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\AmeCapture\data\thumbnails"
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\AmeCapture\data\videos"
 
-# 旧版のキャプチャ画像を新版にコピー（保存先が異なる場合）
+# 2. 旧版のキャプチャ画像を新版にコピー（保存先が異なる場合）
 # 例: 旧版の保存先が Pictures\AmeCapture の場合
 Copy-Item -Recurse "$env:USERPROFILE\Pictures\AmeCapture\originals\*" "$env:LOCALAPPDATA\AmeCapture\data\originals\"
 Copy-Item -Recurse "$env:USERPROFILE\Pictures\AmeCapture\edited\*" "$env:LOCALAPPDATA\AmeCapture\data\edited\"
@@ -111,6 +114,38 @@ Copy-Item -Recurse "$env:USERPROFILE\Pictures\AmeCapture\thumbnails\*" "$env:LOC
 ```
 
 **注意**: データベースをコピーした場合、`workspace_items` テーブルの `original_path`, `current_path`, `thumbnail_path` は旧パスのままです。新しいストレージにファイルを移動した場合は、DB 内のパスも更新する必要があります。ファイルを元の場所に残すか、新しい場所にコピーして DB のパスを更新してください。
+
+#### DB 内パスの更新例
+
+ファイルを新しいストレージに移動した場合、SQLite ツール（`sqlite3` コマンドなど）で以下の SQL を実行してパスを更新します:
+
+```sql
+-- 旧パスのプレフィックスと新パスのプレフィックスを定義して一括更新
+-- 例: C:\Users\<user>\Pictures\AmeCapture → C:\Users\<user>\AppData\Local\AmeCapture\data
+
+UPDATE workspace_items
+SET original_path = REPLACE(original_path,
+    'C:\Users\<ユーザー名>\Pictures\AmeCapture',
+    'C:\Users\<ユーザー名>\AppData\Local\AmeCapture\data')
+WHERE original_path LIKE 'C:\Users\<ユーザー名>\Pictures\AmeCapture%';
+
+UPDATE workspace_items
+SET current_path = REPLACE(current_path,
+    'C:\Users\<ユーザー名>\Pictures\AmeCapture',
+    'C:\Users\<ユーザー名>\AppData\Local\AmeCapture\data')
+WHERE current_path LIKE 'C:\Users\<ユーザー名>\Pictures\AmeCapture%';
+
+UPDATE workspace_items
+SET thumbnail_path = REPLACE(thumbnail_path,
+    'C:\Users\<ユーザー名>\Pictures\AmeCapture',
+    'C:\Users\<ユーザー名>\AppData\Local\AmeCapture\data')
+WHERE thumbnail_path LIKE 'C:\Users\<ユーザー名>\Pictures\AmeCapture%';
+
+-- 更新結果を確認
+SELECT id, original_path, current_path, thumbnail_path FROM workspace_items LIMIT 10;
+```
+
+> `<ユーザー名>` は実際の Windows ユーザー名に置き換えてください。PowerShell では `$env:USERPROFILE` で確認できます。
 
 ## 5. ロールバック手順
 

--- a/documents/ReleaseNotes.md
+++ b/documents/ReleaseNotes.md
@@ -1,0 +1,105 @@
+# AmeCapture — Release Notes
+
+## v1.0.0 — .NET MAUI 正式版
+
+### 概要
+
+AmeCapture が Rust + Tauri v2 + React から **.NET MAUI (C#)** への完全移行を完了し、正式版としてリリースしました。
+
+### 主要変更点
+
+#### アーキテクチャ刷新
+
+| 項目           | 旧 (Tauri/Rust)            | 新 (.NET MAUI)                |
+| -------------- | -------------------------- | ----------------------------- |
+| バックエンド   | Rust (Tauri v2)            | C# (.NET 10)                  |
+| フロントエンド | React + TypeScript         | MAUI XAML + MVVM              |
+| プロセスモデル | マルチプロセス (WebView)   | シングルプロセス (ネイティブ) |
+| IPC            | Tauri IPC (JSON)           | 直接メソッド呼び出し          |
+| 状態管理       | Zustand                    | CommunityToolkit.Mvvm         |
+| 画像処理       | image + imageproc crate    | SkiaSharp                     |
+| DB             | rusqlite                   | Microsoft.Data.Sqlite         |
+| ログ           | tracing + tracing-appender | Serilog                       |
+
+#### 機能（移行済み）
+
+- **画面キャプチャ**: 全画面 / 範囲 / ウィンドウ（GDI+ BitBlt）
+- **画像編集**: 矢印、矩形、テキスト、モザイク、クロップ、Undo/Redo
+- **ワークスペース**: キャプチャ履歴の一覧表示・お気に入り・名前変更・エクスプローラー表示・クリップボードコピー
+- **タグ管理**: タグ CRUD、アイテムへのタグ付け
+- **システムトレイ**: キャプチャメニュー付きトレイ常駐、最小化でトレイに隠す
+- **グローバルショートカット**: 範囲 / 全画面 / ウィンドウキャプチャのホットキー
+- **クリップボード**: キャプチャ後の自動コピー
+- **通知**: キャプチャ完了通知
+- **設定管理**: ホットキー・保存先・画像形式の設定
+
+#### 改善点
+
+- **パフォーマンス**: WebView オーバーヘッドの排除によるネイティブ描画
+- **メモリ管理**: SafeHandle による Win32 リソースの確実な解放
+- **一貫性**: クリーンアーキテクチャによる層分離（Domain / Application / Infrastructure / App）
+- **テスト**: xUnit によるドメイン・インテグレーションテスト
+- **ログ**: Serilog による日次ローテーション・30日保持
+
+### データ互換
+
+- SQLite データベーススキーマは**変更なし**（同じ `CREATE TABLE IF NOT EXISTS`）
+- Tauri 版と MAUI 版は同じ `amecapture.db` を共有可能
+- ファイルストレージ構造（`originals/`, `edited/`, `thumbnails/`, `videos/`）は同一
+
+### 動作環境
+
+- Windows 10 version 1809 (17763) 以降
+- .NET 10 Runtime
+
+### リリース手順
+
+1. `dotnet test src-dotnet/AmeCapture.Tests/` でテスト実行
+2. `dotnet build src-dotnet/AmeCapture.App/ -c Release -f net10.0-windows10.0.19041.0` でリリースビルド
+3. ビルド成果物を配布（unpackaged Win32 アプリケーション）
+4. GitHub Release を作成し、バイナリを添付
+5. リリースノートを GitHub Release に記載
+6. `package.json` のバージョンを更新
+
+---
+
+## 過去のフェーズ
+
+### Phase 1: 基盤構築
+
+- プロジェクトスキャフォールディング
+- CI/CD パイプライン設定
+- SQLite スキーマ設計
+
+### Phase 2: データ層実装
+
+- Repository 実装（Workspace, Tag, Settings）
+- StorageService 実装
+- Settings DTO
+
+### Phase 3: キャプチャ機能実装
+
+- GDI+ BitBlt 画面キャプチャ
+- キャプチャオーケストレーター
+- サムネイル生成
+- ウィンドウ列挙
+
+### Phase 4: エディタ基盤実装
+
+- SkiaSharp ベース画像アノテーション
+- Arrow, Rectangle, Text, Mosaic, Crop
+- Undo/Redo
+
+### Phase 5: 周辺機能実装
+
+- グローバルショートカット
+- システムトレイ
+- クリップボード
+- 通知
+- クリップボードへの画像コピー
+
+### Phase 6: 切り替え・廃止
+
+- MAUI 版を正式版へ昇格
+- 旧 Tauri/Rust 実装の凍結
+- 移行ガイド・リリースノート作成

--- a/src-tauri/FROZEN.md
+++ b/src-tauri/FROZEN.md
@@ -1,0 +1,40 @@
+# ⚠️ FROZEN — Legacy Tauri/Rust Implementation
+
+This directory contains the **frozen legacy implementation** of AmeCapture (Rust + Tauri v2).
+
+**Status:** Deprecated. No further development or bug fixes will be applied.
+
+## Active Implementation
+
+The active implementation is located at `src-dotnet/` (.NET MAUI + C#).
+
+See the [Migration Guide](../documents/MigrationGuide.md) for transition details.
+
+## Freeze Scope
+
+| Item                                            | Status                             |
+| ----------------------------------------------- | ---------------------------------- |
+| `src-tauri/` (Rust backend)                     | Frozen — no changes accepted       |
+| `src/` (React frontend)                         | Frozen — no changes accepted       |
+| `index.html`, `vite.config.ts`, `tsconfig.json` | Frozen — no changes accepted       |
+| `package.json` (Tauri scripts)                  | Retained for legacy reference only |
+
+## Deletion Plan
+
+| Phase    | Action                                                | Timeline                        |
+| -------- | ----------------------------------------------------- | ------------------------------- |
+| Phase 6a | Mark as frozen, add deprecation notices               | **Current**                     |
+| Phase 6b | Remove from CI/CD build pipeline                      | After MAUI stable release       |
+| Phase 6c | Delete `src-tauri/`, `src/`, and related config files | After 1 major version with MAUI |
+| Phase 6d | Remove legacy npm dependencies from `package.json`    | Together with Phase 6c          |
+
+## What is Preserved
+
+- Database schema compatibility (identical `CREATE TABLE IF NOT EXISTS` SQL)
+- Application identifier: `com.amecapture.app`
+- Data directory structure (`originals/`, `edited/`, `thumbnails/`, `videos/`)
+
+## Migration Reference Documents
+
+- [DB Schema & C# Migration Compatibility](../documents/5.%20DB%E3%82%B9%E3%82%AD%E3%83%BC%E3%83%9E%E8%A7%A3%E6%9E%90%E3%81%A8C%23%E7%A7%BB%E8%A1%8C%E4%BA%92%E6%8F%9B%E6%96%B9%E9%87%9D.md)
+- [Migration Guide](../documents/MigrationGuide.md)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+// ⚠️ DEPRECATED: This Tauri/Rust implementation is frozen. Use src-dotnet/ (.NET MAUI) instead.
+// See src-tauri/FROZEN.md for details.
 #![deny(clippy::all)]
 #![deny(warnings)]
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,5 @@
+// ⚠️ DEPRECATED: This Tauri/Rust implementation is frozen. Use src-dotnet/ (.NET MAUI) instead.
+// See src-tauri/FROZEN.md for details.
 #![deny(clippy::all)]
 #![deny(warnings)]
 // Prevents additional console window on Windows in release

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,5 @@
+// ⚠️ DEPRECATED: This React/TypeScript frontend is frozen. Use src-dotnet/ (.NET MAUI) instead.
+// See src-tauri/FROZEN.md for details.
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { logger, installGlobalErrorLogging } from './lib/logger';


### PR DESCRIPTION
## 🎯 概要
AmeCapture のアーキテクチャを **Rust + Tauri v2 + React** から **.NET MAUI (C#) + SkiaSharp** へ完全移行し、MAUI 版を正式版としてリリースするためのプルリクエストです。  
従来実装は「凍結（Frozen）」ステータスとし、今後の開発は .NET MAUI 版に一本化します。

---

## 🔄 主な変更点

### 🏗️ アーキテクチャ刷新
| 項目 | 従来 (Tauri/Rust) | 新規 (.NET MAUI) |
|------|------------------|------------------|
| 🖥️ バックエンド | Rust (Tauri v2) | C# (.NET 10) |
| 🎨 フロントエンド | React + TypeScript | MAUI XAML + MVVM |
| ⚙️ プロセスモデル | マルチプロセス (WebView) | シングルプロセス (ネイティブ) |
| 🔗 通信方式 | Tauri IPC (JSON) | 直接メソッド呼び出し |
| 🗃️ 状態管理 | Zustand | CommunityToolkit.Mvvm |
| 🖼️ 画像処理 | image + imageproc crate | SkiaSharp |
| 🗄️ DBアクセス | rusqlite | Microsoft.Data.Sqlite |
| 📋 ログ出力 | tracing + tracing-appender | Serilog |

### ✨ 機能実装（移行済み）
- 📸 画面キャプチャ: 全画面 / 範囲 / ウィンドウ（GDI+ BitBlt）
- 🎨 画像編集: 矢印・矩形・テキスト・モザイク・クロップ・Undo/Redo
- 🗂️ ワークスペース: キャプチャ履歴の一覧・お気に入り・名前変更・エクスプローラー表示
- 🏷️ タグ管理: タグ CRUD、アイテムへのタグ付け
- 🧩 システムトレイ: キャプチャメニュー付き常駐、最小化でトレイ隠し
- ⌨️ グローバルショートカット: 範囲/全画面/ウィンドウキャプチャのホットキー
- 📋 クリップボード: キャプチャ後の自動コピー・通知機能
- ⚙️ 設定管理: ホットキー・保存先・画像形式の設定

### 📁 追加・更新ファイル
```
📄 README.md                    # 新アーキテクチャへ全面更新
📄 documents/MigrationGuide.md  # 【新規】Tauri→MAUI 移行手順書
📄 documents/ReleaseNotes.md    # 【新規】v1.0.0 MAUI 正式版リリースノート
📄 src-tauri/FROZEN.md          # 【新規】従来実装の凍結に関する告知
📝 src-tauri/src/*.rs           # 非推奨ヘッダーを追加
📝 src/main.tsx                 # 非推奨ヘッダーを追加
```

---

## 🔐 データ互換性について

✅ **自動互換（ユーザー操作不要）**
- SQLite スキーマ: 同一 `CREATE TABLE` 定義
- PRAGMA 設定: `journal_mode=WAL`, `foreign_keys=ON`
- 画像ファイル形式: PNG/JPG 変更なし
- ストレージ構造: `originals/`, `edited/`, `thumbnails/`, `videos/` 維持
- アプリ識別子: `com.amecapture.app` 同一

⚠️ **手動対応が必要な項目**
- データベースパス: `%APPDATA%` → `%LOCALAPPDATA%` へ変更
- 設定データ: JSON+DB → DB のみの形式へ統合
- ログファイル: フォーマット・保存パス変更

📋 詳細な移行手順は [MigrationGuide.md](documents/MigrationGuide.md) をご参照ください。

---

## 🧪 テスト・ビルド手順

```bash
# ✅ 単体テスト実行
dotnet test src-dotnet/AmeCapture.Tests/

# 🏗️ リリースビルド
dotnet build src-dotnet/AmeCapture.App/ -c Release -f net10.0-windows10.0.19041.0

# 🚀 実行
dotnet run --project src-dotnet/AmeCapture.App/AmeCapture.App.csproj -f net10.0-windows10.0.19041.0
```

---

## 📌 動作環境
- 💻 Windows 10 version 1809 (17763) 以降
- 🔧 .NET 10 Runtime
- 🛠️ Visual Studio 2022 17.12+ (MAUI workload 推奨)

---

## 🔍 レビューポイント
- [ ] 新アーキテクチャの層分離（Domain / Application / Infrastructure / App）が適切か
- [ ] SQLite 互換性の維持が担保されているか
- [ ] 移行ガイド・リリースノートの記載に漏れがないか
- [ ] 従来実装への非推奨表記が適切に追加されているか

---

> 💬 **Please write all review comments in Japanese. レビューコメントはすべて日本語で記入してください。**

Closes #197 