### PR TITLE
Change dotnet format severity from info to warn

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -73,4 +73,4 @@ jobs:
         run: dotnet tool install --global dotnet-format
 
       - name: Check formatting
-        run: dotnet format AmeCapture.slnx --verify-no-changes --severity warning
+        run: dotnet format AmeCapture.slnx --verify-no-changes --severity warn

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -73,4 +73,4 @@ jobs:
         run: dotnet tool install --global dotnet-format
 
       - name: Check formatting
-        run: dotnet format AmeCapture.slnx --verify-no-changes --severity info
+        run: dotnet format AmeCapture.slnx --verify-no-changes --severity warning

--- a/src/AmeCapture.App/App.xaml.cs
+++ b/src/AmeCapture.App/App.xaml.cs
@@ -1,7 +1,9 @@
 using AmeCapture.Application.Interfaces;
 using AmeCapture.Application.Messages;
+using AmeCapture.Domain.Entities;
 using AmeCapture.Infrastructure.Database;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.UI;
 
 namespace AmeCapture.App
 {
@@ -32,7 +34,7 @@ namespace AmeCapture.App
                 if (platformWindow != null)
                 {
                     nint hWnd = WinRT.Interop.WindowNative.GetWindowHandle(platformWindow);
-                    var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+                    WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
                     var appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
 
                     appWindow.Closing += (sender, args) =>
@@ -55,7 +57,7 @@ namespace AmeCapture.App
 
             try
             {
-                var services = Handler?.MauiContext?.Services;
+                IServiceProvider? services = Handler?.MauiContext?.Services;
                 if (services == null)
                 {
                     Serilog.Log.Warning("App.OnStart: MauiContext.Services is null");
@@ -63,7 +65,7 @@ namespace AmeCapture.App
                 }
 
                 Serilog.Log.Debug("App.OnStart: registering ExitRequestedMessage");
-                var messenger = services.GetRequiredService<IMessenger>();
+                IMessenger messenger = services.GetRequiredService<IMessenger>();
                 messenger.Register<ExitRequestedMessage>(this, (r, m) =>
                 {
                     Serilog.Log.Debug("App: ExitRequestedMessage received");
@@ -71,11 +73,11 @@ namespace AmeCapture.App
                 });
 
                 Serilog.Log.Debug("App.OnStart: initializing database");
-                var dbFactory = services.GetRequiredService<IDbConnectionFactory>();
+                IDbConnectionFactory dbFactory = services.GetRequiredService<IDbConnectionFactory>();
                 await DatabaseInitializer.InitializeAsync(dbFactory);
 
                 Serilog.Log.Debug("App.OnStart: ensuring storage directories");
-                var storageService = services.GetRequiredService<IStorageService>();
+                IStorageService storageService = services.GetRequiredService<IStorageService>();
                 await storageService.EnsureDirectoriesAsync();
 
                 Serilog.Log.Debug("App.OnStart: initializing tray and shortcuts");
@@ -87,7 +89,7 @@ namespace AmeCapture.App
                 _trayService.Initialize();
 
                 Serilog.Log.Debug("App.OnStart: loading settings and registering shortcuts");
-                var settings = await _settingsRepository.GetAsync();
+                AppSettings settings = await _settingsRepository.GetAsync();
                 await RegisterShortcutsAsync(settings);
 
                 Serilog.Log.Debug("App.OnStart: initialization complete");
@@ -98,7 +100,7 @@ namespace AmeCapture.App
             }
         }
 
-        private async Task RegisterShortcutsAsync(Domain.Entities.AppSettings settings)
+        private async Task RegisterShortcutsAsync(AppSettings settings)
         {
             if (_shortcutService == null)
             {
@@ -107,7 +109,7 @@ namespace AmeCapture.App
 
             Serilog.Log.Debug("App.RegisterShortcutsAsync: region={Region}, fullscreen={Fullscreen}, window={Window}", settings.HotkeyCaptureRegion, settings.HotkeyCaptureFullscreen, settings.HotkeyCaptureWindow);
 
-            var notificationService = Handler?.MauiContext?.Services.GetService<INotificationService>();
+            INotificationService? notificationService = Handler?.MauiContext?.Services.GetService<INotificationService>();
 
             async Task TryRegister(string name, string shortcut, string label, string type)
             {
@@ -122,7 +124,7 @@ namespace AmeCapture.App
                     Serilog.Log.Debug("App: hotkey {Name} triggered, sending CaptureRequestedMessage({Type})", name, type);
                     _ = Dispatcher.Dispatch(() =>
                     {
-                        var messenger = Handler?.MauiContext?.Services.GetService<IMessenger>();
+                        IMessenger? messenger = Handler?.MauiContext?.Services.GetService<IMessenger>();
                         _ = (messenger?.Send(new CaptureRequestedMessage(type)));
                     });
                 });

--- a/src/AmeCapture.App/MauiProgram.cs
+++ b/src/AmeCapture.App/MauiProgram.cs
@@ -48,7 +48,7 @@ namespace AmeCapture.App
                 e.SetObserved();
             };
 
-            var builder = MauiApp.CreateBuilder();
+            MauiAppBuilder builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>

--- a/src/AmeCapture.App/ViewModels/EditorViewModel.cs
+++ b/src/AmeCapture.App/ViewModels/EditorViewModel.cs
@@ -196,7 +196,7 @@ namespace AmeCapture.App.ViewModels
 
             if (PreviewAnnotation is CropAnnotation)
             {
-                var existingCrop = Annotations.OfType<CropAnnotation>().FirstOrDefault();
+                CropAnnotation? existingCrop = Annotations.OfType<CropAnnotation>().FirstOrDefault();
                 if (existingCrop != null)
                 {
                     _ = Annotations.Remove(existingCrop);
@@ -222,7 +222,7 @@ namespace AmeCapture.App.ViewModels
             PushUndoState();
             _redoStack.Clear();
 
-            var annotation = textAnn with { Text = text };
+            TextAnnotation annotation = textAnn with { Text = text };
             Annotations.Add(annotation);
             PreviewAnnotation = null;
             IsDirty = true;
@@ -233,7 +233,7 @@ namespace AmeCapture.App.ViewModels
 
         public void RemoveAnnotation(string id)
         {
-            var annotation = Annotations.FirstOrDefault(a => a.Id == id);
+            Annotation? annotation = Annotations.FirstOrDefault(a => a.Id == id);
             if (annotation == null)
             {
                 return;
@@ -259,10 +259,10 @@ namespace AmeCapture.App.ViewModels
             Serilog.Log.Debug("EditorViewModel.Undo: restoring from undo stack (depth={Depth})", _undoStack.Count);
             _redoStack.Add([.. Annotations]);
             int lastIndex = _undoStack.Count - 1;
-            var previous = _undoStack[lastIndex];
+            IReadOnlyList<Annotation> previous = _undoStack[lastIndex];
             _undoStack.RemoveAt(lastIndex);
             Annotations.Clear();
-            foreach (var a in previous)
+            foreach (Annotation a in previous)
             {
                 Annotations.Add(a);
             }
@@ -284,10 +284,10 @@ namespace AmeCapture.App.ViewModels
             Serilog.Log.Debug("EditorViewModel.Redo: restoring from redo stack (depth={Depth})", _redoStack.Count);
             _undoStack.Add([.. Annotations]);
             int lastIndex = _redoStack.Count - 1;
-            var next = _redoStack[lastIndex];
+            IReadOnlyList<Annotation> next = _redoStack[lastIndex];
             _redoStack.RemoveAt(lastIndex);
             Annotations.Clear();
-            foreach (var a in next)
+            foreach (Annotation a in next)
             {
                 Annotations.Add(a);
             }

--- a/src/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
@@ -94,7 +94,7 @@ namespace AmeCapture.App.ViewModels
             {
                 IReadOnlyList<WorkspaceItem> items = await _workspaceRepository.GetAllAsync();
                 Items.Clear();
-                foreach (WorkspaceItem? item in items.OrderByDescending(i => i.CreatedAt))
+                foreach (WorkspaceItem item in items.OrderByDescending(i => i.CreatedAt))
                 {
                     Items.Add(item);
                 }

--- a/src/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/AmeCapture.App/ViewModels/WorkspaceViewModel.cs
@@ -92,9 +92,9 @@ namespace AmeCapture.App.ViewModels
             Serilog.Log.Debug("WorkspaceViewModel.LoadItemsAsync started");
             try
             {
-                var items = await _workspaceRepository.GetAllAsync();
+                IReadOnlyList<WorkspaceItem> items = await _workspaceRepository.GetAllAsync();
                 Items.Clear();
-                foreach (var item in items.OrderByDescending(i => i.CreatedAt))
+                foreach (WorkspaceItem? item in items.OrderByDescending(i => i.CreatedAt))
                 {
                     Items.Add(item);
                 }
@@ -119,7 +119,7 @@ namespace AmeCapture.App.ViewModels
             IsCapturing = true;
             try
             {
-                var item = await _captureOrchestrator.CaptureFullScreenAsync();
+                WorkspaceItem item = await _captureOrchestrator.CaptureFullScreenAsync();
                 Items.Insert(0, item);
                 Serilog.Log.Debug("WorkspaceViewModel: fullscreen capture item added, ItemId={ItemId}", item.Id);
                 await NotifyCaptureCompleteAsync(item);
@@ -146,7 +146,7 @@ namespace AmeCapture.App.ViewModels
             IsCapturing = true;
             try
             {
-                var item = await _captureOrchestrator.CaptureWindowAsync(hwnd);
+                WorkspaceItem item = await _captureOrchestrator.CaptureWindowAsync(hwnd);
                 Items.Insert(0, item);
                 IsWindowSelectionMode = false;
                 Serilog.Log.Debug("WorkspaceViewModel: window capture item added, ItemId={ItemId}", item.Id);
@@ -199,7 +199,7 @@ namespace AmeCapture.App.ViewModels
             IsCapturing = true;
             try
             {
-                var item = await _captureOrchestrator.FinalizeRegionCaptureAsync(
+                WorkspaceItem item = await _captureOrchestrator.FinalizeRegionCaptureAsync(
                     RegionCaptureInfo.TempPath, region);
                 Items.Insert(0, item);
                 RegionCaptureInfo = null;
@@ -247,9 +247,9 @@ namespace AmeCapture.App.ViewModels
             IsCapturing = true;
             try
             {
-                var windows = await _captureOrchestrator.PrepareWindowCaptureAsync();
+                IReadOnlyList<WindowInfo> windows = await _captureOrchestrator.PrepareWindowCaptureAsync();
                 Windows.Clear();
-                foreach (var w in windows)
+                foreach (WindowInfo w in windows)
                 {
                     Windows.Add(w);
                 }

--- a/src/AmeCapture.App/Views/EditorPage.xaml.cs
+++ b/src/AmeCapture.App/Views/EditorPage.xaml.cs
@@ -47,7 +47,7 @@ namespace AmeCapture.App.Views
             try
             {
                 Serilog.Log.Debug("EditorPage.LoadItemAsync: itemId={ItemId}", itemId);
-                var item = await _workspaceRepository.GetByIdAsync(itemId);
+                WorkspaceItem? item = await _workspaceRepository.GetByIdAsync(itemId);
                 if (item != null)
                 {
                     _viewModel.LoadItem(item);
@@ -95,7 +95,7 @@ namespace AmeCapture.App.Views
 
         private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
         {
-            var canvas = e.Surface.Canvas;
+            SKCanvas canvas = e.Surface.Canvas;
             canvas.Clear(SKColors.White);
 
             if (_sourceBitmap == null)
@@ -115,7 +115,7 @@ namespace AmeCapture.App.Views
                 canvas.DrawBitmap(_sourceBitmap, 0, 0, paint);
             }
 
-            foreach (var annotation in _viewModel.Annotations)
+            foreach (Annotation annotation in _viewModel.Annotations)
             {
                 DrawAnnotation(canvas, annotation, _sourceBitmap.Width, _sourceBitmap.Height);
             }
@@ -154,7 +154,7 @@ namespace AmeCapture.App.Views
 
         private static void DrawArrow(SKCanvas canvas, ArrowAnnotation arrow)
         {
-            var color = ParseColor(arrow.StrokeColor);
+            SKColor color = ParseColor(arrow.StrokeColor);
             using var paint = new SKPaint
             {
                 Color = color,
@@ -193,7 +193,7 @@ namespace AmeCapture.App.Views
 
         private static void DrawRectangle(SKCanvas canvas, RectangleAnnotation rect)
         {
-            var color = ParseColor(rect.StrokeColor);
+            SKColor color = ParseColor(rect.StrokeColor);
             using var paint = new SKPaint
             {
                 Color = color,
@@ -237,7 +237,7 @@ namespace AmeCapture.App.Views
 
         private static void DrawText(SKCanvas canvas, TextAnnotation text)
         {
-            var color = ParseColor(text.StrokeColor);
+            SKColor color = ParseColor(text.StrokeColor);
             using var font = new SKFont
             {
                 Size = (float)text.FontSize,
@@ -250,7 +250,7 @@ namespace AmeCapture.App.Views
                 Style = SKPaintStyle.Fill,
             };
 
-            var metrics = font.Metrics;
+            SKFontMetrics metrics = font.Metrics;
             float baselineOffset = -metrics.Ascent;
             float lineHeight = metrics.Descent - metrics.Ascent + metrics.Leading;
 

--- a/src/AmeCapture.Infrastructure/Database/DatabaseInitializer.cs
+++ b/src/AmeCapture.Infrastructure/Database/DatabaseInitializer.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using AmeCapture.Application.Interfaces;
 
 namespace AmeCapture.Infrastructure.Database
@@ -7,9 +8,9 @@ namespace AmeCapture.Infrastructure.Database
         public static async Task InitializeAsync(IDbConnectionFactory connectionFactory)
         {
             Serilog.Log.Debug("DatabaseInitializer.InitializeAsync started");
-            using var connection = await connectionFactory.CreateConnectionAsync();
-            using var transaction = await connection.BeginTransactionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await connectionFactory.CreateConnectionAsync();
+            using DbTransaction transaction = await connection.BeginTransactionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.Transaction = transaction;
             command.CommandText = @"
             CREATE TABLE IF NOT EXISTS workspace_items (

--- a/src/AmeCapture.Infrastructure/Database/SqliteConnectionFactory.cs
+++ b/src/AmeCapture.Infrastructure/Database/SqliteConnectionFactory.cs
@@ -15,7 +15,7 @@ namespace AmeCapture.Infrastructure.Database
             var connection = new SqliteConnection(_connectionString);
             await connection.OpenAsync();
 
-            using var cmd = connection.CreateCommand();
+            using SqliteCommand cmd = connection.CreateCommand();
             cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
             _ = await cmd.ExecuteNonQueryAsync();
 

--- a/src/AmeCapture.Infrastructure/Repositories/SettingsRepository.cs
+++ b/src/AmeCapture.Infrastructure/Repositories/SettingsRepository.cs
@@ -10,13 +10,13 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task<AppSettings> GetAsync()
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "SELECT key, value FROM app_settings ORDER BY key";
 
             var settings = new AppSettings();
 
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 string key = reader.GetString(0);
@@ -52,8 +52,8 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task SaveAsync(AppSettings settings)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var transaction = await connection.BeginTransactionAsync();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbTransaction transaction = await connection.BeginTransactionAsync();
 
             try
             {
@@ -77,17 +77,17 @@ namespace AmeCapture.Infrastructure.Repositories
         private static async Task UpsertAsync(DbConnection connection, DbTransaction transaction,
             string key, string value)
         {
-            using var command = connection.CreateCommand();
+            using DbCommand command = connection.CreateCommand();
             command.Transaction = transaction;
             command.CommandText = @"
             INSERT INTO app_settings (key, value) VALUES (@key, @value)
             ON CONFLICT(key) DO UPDATE SET value = @value";
-            var keyParam = command.CreateParameter();
+            DbParameter keyParam = command.CreateParameter();
             keyParam.ParameterName = "@key";
             keyParam.Value = key;
             _ = command.Parameters.Add(keyParam);
 
-            var valueParam = command.CreateParameter();
+            DbParameter valueParam = command.CreateParameter();
             valueParam.ParameterName = "@value";
             valueParam.Value = value;
             _ = command.Parameters.Add(valueParam);

--- a/src/AmeCapture.Infrastructure/Repositories/TagRepository.cs
+++ b/src/AmeCapture.Infrastructure/Repositories/TagRepository.cs
@@ -11,12 +11,12 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task<IReadOnlyList<Tag>> GetAllAsync()
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "SELECT id, name FROM tags ORDER BY name";
 
             var tags = new List<Tag>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 tags.Add(ReadTag(reader));
@@ -27,30 +27,30 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task<Tag?> GetByIdAsync(string id)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "SELECT id, name FROM tags WHERE id = @id";
             AddParameter(command, "@id", id);
 
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             return await reader.ReadAsync() ? ReadTag(reader) : null;
         }
 
         public async Task<Tag?> FindByNameAsync(string name)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "SELECT id, name FROM tags WHERE name = @name";
             AddParameter(command, "@name", name);
 
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             return await reader.ReadAsync() ? ReadTag(reader) : null;
         }
 
         public async Task AddAsync(Tag tag)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "INSERT INTO tags (id, name) VALUES (@id, @name)";
             AddParameter(command, "@id", tag.Id);
             AddParameter(command, "@name", tag.Name);
@@ -60,8 +60,8 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task DeleteAsync(string id)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "DELETE FROM tags WHERE id = @id";
             AddParameter(command, "@id", id);
 
@@ -70,8 +70,8 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task<IReadOnlyList<Tag>> GetTagsForItemAsync(string itemId)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             SELECT t.id, t.name FROM tags t
             INNER JOIN workspace_item_tags wit ON t.id = wit.tag_id
@@ -80,7 +80,7 @@ namespace AmeCapture.Infrastructure.Repositories
             AddParameter(command, "@itemId", itemId);
 
             var tags = new List<Tag>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 tags.Add(ReadTag(reader));
@@ -91,8 +91,8 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task AddTagToItemAsync(string itemId, string tagId)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (@itemId, @tagId)";
             AddParameter(command, "@itemId", itemId);
@@ -103,8 +103,8 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task RemoveTagFromItemAsync(string itemId, string tagId)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             DELETE FROM workspace_item_tags WHERE workspace_item_id = @itemId AND tag_id = @tagId";
             AddParameter(command, "@itemId", itemId);
@@ -115,12 +115,12 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task SetTagsForItemAsync(string itemId, IEnumerable<string> tagIds)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var transaction = await connection.BeginTransactionAsync();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbTransaction transaction = await connection.BeginTransactionAsync();
 
             try
             {
-                using (var deleteCommand = connection.CreateCommand())
+                using (DbCommand deleteCommand = connection.CreateCommand())
                 {
                     deleteCommand.Transaction = transaction;
                     deleteCommand.CommandText =
@@ -129,13 +129,13 @@ namespace AmeCapture.Infrastructure.Repositories
                     _ = await deleteCommand.ExecuteNonQueryAsync();
                 }
 
-                using (var insertCommand = connection.CreateCommand())
+                using (DbCommand insertCommand = connection.CreateCommand())
                 {
                     insertCommand.Transaction = transaction;
                     insertCommand.CommandText = @"
                     INSERT OR IGNORE INTO workspace_item_tags (workspace_item_id, tag_id) VALUES (@itemId, @tagId)";
                     AddParameter(insertCommand, "@itemId", itemId);
-                    var tagParam = insertCommand.CreateParameter();
+                    DbParameter tagParam = insertCommand.CreateParameter();
                     tagParam.ParameterName = "@tagId";
                     _ = insertCommand.Parameters.Add(tagParam);
 
@@ -157,14 +157,14 @@ namespace AmeCapture.Infrastructure.Repositories
 
         public async Task<IReadOnlyList<string>> GetItemIdsByTagAsync(string tagId)
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText =
                 "SELECT workspace_item_id FROM workspace_item_tags WHERE tag_id = @tagId";
             AddParameter(command, "@tagId", tagId);
 
             var ids = new List<string>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 ids.Add(reader.GetString(0));
@@ -188,8 +188,8 @@ namespace AmeCapture.Infrastructure.Repositories
                 map[id] = [];
             }
 
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             SELECT wit.workspace_item_id, t.id, t.name
             FROM workspace_item_tags wit
@@ -198,7 +198,7 @@ namespace AmeCapture.Infrastructure.Repositories
             ORDER BY t.name";
             AddParameter(command, "@ids", JsonSerializer.Serialize(idList));
 
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 string itemId = reader.GetString(0);
@@ -216,7 +216,7 @@ namespace AmeCapture.Infrastructure.Repositories
 
         private static void AddParameter(DbCommand command, string name, object value)
         {
-            var param = command.CreateParameter();
+            DbParameter param = command.CreateParameter();
             param.ParameterName = name;
             param.Value = value;
             _ = command.Parameters.Add(param);

--- a/src/AmeCapture.Infrastructure/Repositories/WorkspaceRepository.cs
+++ b/src/AmeCapture.Infrastructure/Repositories/WorkspaceRepository.cs
@@ -12,8 +12,8 @@ namespace AmeCapture.Infrastructure.Repositories
         public async Task<IReadOnlyList<WorkspaceItem>> GetAllAsync()
         {
             Serilog.Log.Debug("WorkspaceRepository.GetAllAsync");
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             SELECT id, type, original_path, current_path, thumbnail_path,
                    title, created_at, updated_at, is_favorite, metadata_json
@@ -21,7 +21,7 @@ namespace AmeCapture.Infrastructure.Repositories
             ORDER BY created_at DESC";
 
             var items = new List<WorkspaceItem>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 items.Add(ReadWorkspaceItem(reader));
@@ -34,18 +34,18 @@ namespace AmeCapture.Infrastructure.Repositories
         public async Task<WorkspaceItem?> GetByIdAsync(string id)
         {
             Serilog.Log.Debug("WorkspaceRepository.GetByIdAsync: {ItemId}", id);
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             SELECT id, type, original_path, current_path, thumbnail_path,
                    title, created_at, updated_at, is_favorite, metadata_json
             FROM workspace_items WHERE id = @id";
             AddParameter(command, "@id", id);
 
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             if (await reader.ReadAsync())
             {
-                var item = ReadWorkspaceItem(reader);
+                WorkspaceItem item = ReadWorkspaceItem(reader);
                 Serilog.Log.Debug("WorkspaceRepository.GetByIdAsync: found item {ItemId}", id);
                 return item;
             }
@@ -57,8 +57,8 @@ namespace AmeCapture.Infrastructure.Repositories
         public async Task AddAsync(WorkspaceItem item)
         {
             Serilog.Log.Debug("WorkspaceRepository.AddAsync: {ItemId}, title={Title}", item.Id, item.Title);
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             INSERT INTO workspace_items
                 (id, type, original_path, current_path, thumbnail_path,
@@ -84,8 +84,8 @@ namespace AmeCapture.Infrastructure.Repositories
         public async Task UpdateAsync(WorkspaceItem item)
         {
             Serilog.Log.Debug("WorkspaceRepository.UpdateAsync: {ItemId}", item.Id);
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             UPDATE workspace_items SET
                 type = @type, original_path = @original_path, current_path = @current_path,
@@ -110,8 +110,8 @@ namespace AmeCapture.Infrastructure.Repositories
         public async Task DeleteAsync(string id)
         {
             Serilog.Log.Debug("WorkspaceRepository.DeleteAsync: {ItemId}", id);
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = "DELETE FROM workspace_items WHERE id = @id";
             AddParameter(command, "@id", id);
 
@@ -127,8 +127,8 @@ namespace AmeCapture.Infrastructure.Repositories
                 return [];
             }
 
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText = @"
             SELECT id, type, original_path, current_path, thumbnail_path,
                    title, created_at, updated_at, is_favorite, metadata_json
@@ -136,7 +136,7 @@ namespace AmeCapture.Infrastructure.Repositories
             AddParameter(command, "@ids", JsonSerializer.Serialize(idList));
 
             var items = new List<WorkspaceItem>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 items.Add(ReadWorkspaceItem(reader));
@@ -170,7 +170,7 @@ namespace AmeCapture.Infrastructure.Repositories
 
         private static void AddParameter(DbCommand command, string name, object value)
         {
-            var param = command.CreateParameter();
+            DbParameter param = command.CreateParameter();
             param.ParameterName = name;
             param.Value = value;
             _ = command.Parameters.Add(param);

--- a/src/AmeCapture.Infrastructure/Services/CaptureOrchestrator.cs
+++ b/src/AmeCapture.Infrastructure/Services/CaptureOrchestrator.cs
@@ -32,7 +32,7 @@ namespace AmeCapture.Infrastructure.Services
             string thumbPath = _storageService.ResolveThumbnailPath(filename);
             Serilog.Log.Debug("Paths resolved - original={OriginalPath}, edited={EditedPath}, thumb={ThumbPath}", originalPath, editedPath, thumbPath);
 
-            var captureResult = await _captureService.CaptureFullScreenAsync(originalPath);
+            CaptureResult captureResult = await _captureService.CaptureFullScreenAsync(originalPath);
             Serilog.Log.Debug("Capture result: {Width}x{Height}", captureResult.Width, captureResult.Height);
 
             File.Copy(originalPath, editedPath, overwrite: true);
@@ -75,7 +75,7 @@ namespace AmeCapture.Infrastructure.Services
             string editedPath = _storageService.ResolveEditedPath(filename);
             string thumbPath = _storageService.ResolveThumbnailPath(filename);
 
-            var captureResult = await _captureService.CaptureWindowAsync(hwnd, originalPath);
+            CaptureResult captureResult = await _captureService.CaptureWindowAsync(hwnd, originalPath);
             Serilog.Log.Debug("Window capture result: {Width}x{Height}", captureResult.Width, captureResult.Height);
 
             File.Copy(originalPath, editedPath, overwrite: true);
@@ -111,7 +111,7 @@ namespace AmeCapture.Infrastructure.Services
             string tempPath = Path.Combine(tempDir, $"amecapture_region_{Guid.NewGuid():N}.png");
             Serilog.Log.Debug("Region temp path: {TempPath}", tempPath);
 
-            var captureResult = await _captureService.CaptureFullScreenAsync(tempPath);
+            CaptureResult captureResult = await _captureService.CaptureFullScreenAsync(tempPath);
             Serilog.Log.Debug("Region capture prepared: {Width}x{Height}", captureResult.Width, captureResult.Height);
 
             return new RegionCaptureInfo
@@ -207,7 +207,7 @@ namespace AmeCapture.Infrastructure.Services
         public async Task<IReadOnlyList<WindowInfo>> PrepareWindowCaptureAsync()
         {
             Serilog.Log.Debug("CaptureOrchestrator.PrepareWindowCaptureAsync started");
-            var windows = await _windowEnumerationService.EnumerateWindowsAsync();
+            IReadOnlyList<WindowInfo> windows = await _windowEnumerationService.EnumerateWindowsAsync();
             Serilog.Log.Debug("PrepareWindowCaptureAsync: found {Count} windows", windows.Count);
             return windows;
         }

--- a/src/AmeCapture.Infrastructure/Services/CaptureService.cs
+++ b/src/AmeCapture.Infrastructure/Services/CaptureService.cs
@@ -39,7 +39,7 @@ namespace AmeCapture.Infrastructure.Services
                     throw new InvalidOperationException("BitBlt failed.");
                 }
 
-                using var img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+                using Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
                 img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
                 Serilog.Log.Debug("Image saved to {SavePath}, size={Size} bytes", savePath, new FileInfo(savePath).Length);
 
@@ -68,7 +68,7 @@ namespace AmeCapture.Infrastructure.Services
                     _ = Directory.CreateDirectory(dir);
                 }
 
-                var (left, top, right, bottom) = GetWindowBounds(hwnd);
+                (int left, int top, int right, int bottom) = GetWindowBounds(hwnd);
                 int width = right - left;
                 int height = bottom - top;
                 Serilog.Log.Debug("Window bounds: left={Left}, top={Top}, right={Right}, bottom={Bottom}, size={Width}x{Height}", left, top, right, bottom, width, height);
@@ -90,7 +90,7 @@ namespace AmeCapture.Infrastructure.Services
                     throw new InvalidOperationException("BitBlt failed.");
                 }
 
-                using var img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+                using Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
                 img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
                 Serilog.Log.Debug("Window image saved to {SavePath}, size={Size} bytes", savePath, new FileInfo(savePath).Length);
 

--- a/src/AmeCapture.Infrastructure/Services/CaptureService.cs
+++ b/src/AmeCapture.Infrastructure/Services/CaptureService.cs
@@ -39,7 +39,7 @@ namespace AmeCapture.Infrastructure.Services
                     throw new InvalidOperationException("BitBlt failed.");
                 }
 
-                using Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+                using System.Drawing.Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
                 img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
                 Serilog.Log.Debug("Image saved to {SavePath}, size={Size} bytes", savePath, new FileInfo(savePath).Length);
 
@@ -90,7 +90,7 @@ namespace AmeCapture.Infrastructure.Services
                     throw new InvalidOperationException("BitBlt failed.");
                 }
 
-                using Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+                using System.Drawing.Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
                 img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
                 Serilog.Log.Debug("Window image saved to {SavePath}, size={Size} bytes", savePath, new FileInfo(savePath).Length);
 

--- a/src/AmeCapture.Infrastructure/Services/CaptureService.cs
+++ b/src/AmeCapture.Infrastructure/Services/CaptureService.cs
@@ -39,7 +39,7 @@ namespace AmeCapture.Infrastructure.Services
                     throw new InvalidOperationException("BitBlt failed.");
                 }
 
-                using System.Drawing.Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+                using Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
                 img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
                 Serilog.Log.Debug("Image saved to {SavePath}, size={Size} bytes", savePath, new FileInfo(savePath).Length);
 
@@ -90,7 +90,7 @@ namespace AmeCapture.Infrastructure.Services
                     throw new InvalidOperationException("BitBlt failed.");
                 }
 
-                using System.Drawing.Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
+                using Bitmap img = System.Drawing.Image.FromHbitmap(bitmap.DangerousGetHandle());
                 img.Save(savePath, System.Drawing.Imaging.ImageFormat.Png);
                 Serilog.Log.Debug("Window image saved to {SavePath}, size={Size} bytes", savePath, new FileInfo(savePath).Length);
 

--- a/src/AmeCapture.Infrastructure/Services/GlobalShortcutService.cs
+++ b/src/AmeCapture.Infrastructure/Services/GlobalShortcutService.cs
@@ -37,7 +37,7 @@ namespace AmeCapture.Infrastructure.Services
 
                     while (_running)
                     {
-                        if (NativeMethods.PeekMessage(out var msg, IntPtr.Zero, 0, 0, 1))
+                        if (NativeMethods.PeekMessage(out Msg msg, IntPtr.Zero, 0, 0, 1))
                         {
                             _ = NativeMethods.TranslateMessage(ref msg);
                             _ = NativeMethods.DispatchMessage(ref msg);
@@ -66,7 +66,7 @@ namespace AmeCapture.Infrastructure.Services
             try
             {
                 var delayTask = Task.Delay(TimeSpan.FromSeconds(5));
-                var completedTask = await Task.WhenAny(_initTcs.Task, delayTask);
+                Task completedTask = await Task.WhenAny(_initTcs.Task, delayTask);
                 if (completedTask == delayTask)
                 {
                     Serilog.Log.Error("GlobalShortcutService initialization timed out");
@@ -92,7 +92,7 @@ namespace AmeCapture.Infrastructure.Services
                 Serilog.Log.Debug("WM_HOTKEY received, hotKeyId={HotKeyId}", hotKeyId);
                 lock (_lock)
                 {
-                    foreach (var info in _hotKeys.Values)
+                    foreach (HotKeyInfo info in _hotKeys.Values)
                     {
                         if (info.Id == hotKeyId)
                         {
@@ -125,7 +125,7 @@ namespace AmeCapture.Infrastructure.Services
                     UnregisterHotKey(name);
                 }
 
-                var keys = ParseShortcut(shortcut);
+                (int Modifiers, int VirtualKey) keys = ParseShortcut(shortcut);
                 int id = Interlocked.Increment(ref _nextId);
                 Serilog.Log.Debug("RegisterHotKey: parsed modifiers={Modifiers}, virtualKey={VirtualKey}, id={Id}", keys.Modifiers, keys.VirtualKey, id);
 
@@ -153,7 +153,7 @@ namespace AmeCapture.Infrastructure.Services
             Serilog.Log.Debug("UnregisterHotKey: name={Name}", name);
             lock (_lock)
             {
-                if (_hotKeys.TryGetValue(name, out var info))
+                if (_hotKeys.TryGetValue(name, out HotKeyInfo? info))
                 {
                     _ = NativeMethods.UnregisterHotKey(_messageWindow, info.Id);
                     _ = _hotKeys.Remove(name);
@@ -167,7 +167,7 @@ namespace AmeCapture.Infrastructure.Services
             Serilog.Log.Debug("UnregisterAll: clearing {Count} hotkeys", _hotKeys.Count);
             lock (_lock)
             {
-                foreach (var info in _hotKeys.Values)
+                foreach (HotKeyInfo info in _hotKeys.Values)
                 {
                     _ = NativeMethods.UnregisterHotKey(_messageWindow, info.Id);
                 }

--- a/src/AmeCapture.Infrastructure/Services/SkiaSharpEditorService.cs
+++ b/src/AmeCapture.Infrastructure/Services/SkiaSharpEditorService.cs
@@ -15,11 +15,11 @@ namespace AmeCapture.Infrastructure.Services
 
             await Task.Run(() =>
             {
-                using var original = SKBitmap.Decode(sourcePath) ?? throw new InvalidOperationException($"Failed to load image: {sourcePath}");
+                using SKBitmap original = SKBitmap.Decode(sourcePath) ?? throw new InvalidOperationException($"Failed to load image: {sourcePath}");
 
                 Serilog.Log.Debug("SkiaSharpEditorService: source image decoded, {Width}x{Height}", original.Width, original.Height);
 
-                var cropAnnotation = annotations.OfType<CropAnnotation>().FirstOrDefault();
+                CropAnnotation? cropAnnotation = annotations.OfType<CropAnnotation>().FirstOrDefault();
 
                 SKBitmap workingBitmap;
                 double offsetX = 0, offsetY = 0;
@@ -37,7 +37,7 @@ namespace AmeCapture.Infrastructure.Services
                 }
 
                 using var surface = SKSurface.Create(new SKImageInfo(workingBitmap.Width, workingBitmap.Height));
-                var canvas = surface.Canvas;
+                SKCanvas canvas = surface.Canvas;
 
                 using (var paint = new SKPaint())
                 {
@@ -45,7 +45,7 @@ namespace AmeCapture.Infrastructure.Services
                     canvas.DrawBitmap(workingBitmap, 0, 0, paint);
                 }
 
-                foreach (var annotation in annotations)
+                foreach (Annotation annotation in annotations)
                 {
                     Serilog.Log.Debug("SkiaSharpEditorService: applying annotation type={Type}", annotation.GetType().Name);
                     switch (annotation)
@@ -88,15 +88,15 @@ namespace AmeCapture.Infrastructure.Services
                     }
                 }
 
-                using var image = surface.Snapshot();
-                using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+                using SKImage image = surface.Snapshot();
+                using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
                 string? dir = Path.GetDirectoryName(outputPath);
                 if (!string.IsNullOrEmpty(dir))
                 {
                     _ = Directory.CreateDirectory(dir);
                 }
 
-                using var stream = File.Create(outputPath);
+                using FileStream stream = File.Create(outputPath);
                 data.SaveTo(stream);
 
                 workingBitmap.Dispose();
@@ -126,7 +126,7 @@ namespace AmeCapture.Infrastructure.Services
 
         private static void DrawArrow(SKCanvas canvas, ArrowAnnotation arrow)
         {
-            var color = ParseColor(arrow.StrokeColor);
+            SKColor color = ParseColor(arrow.StrokeColor);
             int width = Math.Max(1, arrow.StrokeWidth);
 
             using var linePaint = new SKPaint
@@ -171,7 +171,7 @@ namespace AmeCapture.Infrastructure.Services
 
         private static void DrawRectangle(SKCanvas canvas, RectangleAnnotation rect)
         {
-            var color = ParseColor(rect.StrokeColor);
+            SKColor color = ParseColor(rect.StrokeColor);
             int width = Math.Max(1, rect.StrokeWidth);
 
             using var paint = new SKPaint
@@ -263,7 +263,7 @@ namespace AmeCapture.Infrastructure.Services
 
         private static void DrawText(SKCanvas canvas, TextAnnotation text)
         {
-            var color = ParseColor(text.StrokeColor);
+            SKColor color = ParseColor(text.StrokeColor);
 
             using var font = new SKFont
             {

--- a/src/AmeCapture.Infrastructure/Services/StorageService.cs
+++ b/src/AmeCapture.Infrastructure/Services/StorageService.cs
@@ -25,7 +25,7 @@ namespace AmeCapture.Infrastructure.Services
         public async Task EnsureDirectoriesAsync()
         {
             Serilog.Log.Debug("StorageService.EnsureDirectoriesAsync: basePath={BasePath}", _basePath);
-            string[] dirs = new[] { DirOriginals, DirEdited, DirThumbnails, DirVideos };
+            string[] dirs = [DirOriginals, DirEdited, DirThumbnails, DirVideos];
             foreach (string? dir in dirs)
             {
                 string path = Path.Combine(_basePath, dir);

--- a/src/AmeCapture.Infrastructure/Services/TrayService.cs
+++ b/src/AmeCapture.Infrastructure/Services/TrayService.cs
@@ -83,7 +83,7 @@ namespace AmeCapture.Infrastructure.Services
         {
             MainThread.BeginInvokeOnMainThread(() =>
             {
-                var window = Microsoft.Maui.Controls.Application.Current?.Windows[0];
+                Window? window = Microsoft.Maui.Controls.Application.Current?.Windows[0];
                 if (window != null)
                 {
                     var platformWindow = window.Handler?.PlatformView as Microsoft.UI.Xaml.Window;
@@ -101,7 +101,7 @@ namespace AmeCapture.Infrastructure.Services
         {
             MainThread.BeginInvokeOnMainThread(() =>
             {
-                var window = Microsoft.Maui.Controls.Application.Current?.Windows[0];
+                Window? window = Microsoft.Maui.Controls.Application.Current?.Windows[0];
                 if (window != null)
                 {
                     var platformWindow = window.Handler?.PlatformView as Microsoft.UI.Xaml.Window;

--- a/tests/AmeCapture.Tests/Domain/AnnotationTests.cs
+++ b/tests/AmeCapture.Tests/Domain/AnnotationTests.cs
@@ -7,7 +7,7 @@ namespace AmeCapture.Tests.Domain
         [Fact]
         public void ArrowAnnotation_DefaultValues_AreSet()
         {
-            var ann =  new ArrowAnnotation();
+            var ann = new ArrowAnnotation();
 
             Assert.NotEqual(string.Empty, ann.Id);
             Assert.Equal("arrow", ann.Type);

--- a/tests/AmeCapture.Tests/Domain/AnnotationTests.cs
+++ b/tests/AmeCapture.Tests/Domain/AnnotationTests.cs
@@ -142,7 +142,7 @@ namespace AmeCapture.Tests.Domain
                 StrokeWidth = 5,
             };
 
-            var copy = original with { EndX = 150, EndY = 250 };
+            ArrowAnnotation copy = original with { EndX = 150, EndY = 250 };
 
             Assert.Equal(10, copy.StartX);
             Assert.Equal(20, copy.StartY);

--- a/tests/AmeCapture.Tests/Domain/AnnotationTests.cs
+++ b/tests/AmeCapture.Tests/Domain/AnnotationTests.cs
@@ -7,7 +7,7 @@ namespace AmeCapture.Tests.Domain
         [Fact]
         public void ArrowAnnotation_DefaultValues_AreSet()
         {
-            var ann = new ArrowAnnotation();
+            var ann =  new ArrowAnnotation();
 
             Assert.NotEqual(string.Empty, ann.Id);
             Assert.Equal("arrow", ann.Type);

--- a/tests/AmeCapture.Tests/Integration/EditorServiceTests.cs
+++ b/tests/AmeCapture.Tests/Integration/EditorServiceTests.cs
@@ -1,5 +1,6 @@
 using AmeCapture.Domain.Entities;
 using AmeCapture.Infrastructure.Services;
+using SkiaSharp;
 
 namespace AmeCapture.Tests.Integration
 {
@@ -36,14 +37,14 @@ namespace AmeCapture.Tests.Integration
         private string CreateTestImage(int width = 100, int height = 100)
         {
             string path = Path.Combine(_tempDir, $"test_{Guid.NewGuid():N}.png");
-            using var bitmap = new SkiaSharp.SKBitmap(width, height);
-            using var canvas = new SkiaSharp.SKCanvas(bitmap);
-            canvas.Clear(new SkiaSharp.SKColor(200, 200, 200, 255));
+            using var bitmap = new SKBitmap(width, height);
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(new SKColor(200, 200, 200, 255));
             canvas.Flush();
 
-            using var image = SkiaSharp.SKImage.FromBitmap(bitmap);
-            using var data = image.Encode(SkiaSharp.SKEncodedImageFormat.Png, 100);
-            using var stream = File.OpenWrite(path);
+            using var image = SKImage.FromBitmap(bitmap);
+            using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using FileStream stream = File.OpenWrite(path);
             data.SaveTo(stream);
 
             return path;
@@ -79,7 +80,7 @@ namespace AmeCapture.Tests.Integration
             await _editorService.ApplyAnnotationsAsync(sourcePath, outputPath, annotations);
 
             Assert.True(File.Exists(outputPath));
-            using var result = SkiaSharp.SKBitmap.Decode(outputPath);
+            using var result = SKBitmap.Decode(outputPath);
             Assert.NotNull(result);
             Assert.Equal(100, result.Width);
             Assert.Equal(100, result.Height);
@@ -163,7 +164,7 @@ namespace AmeCapture.Tests.Integration
             await _editorService.ApplyAnnotationsAsync(sourcePath, outputPath, annotations);
 
             Assert.True(File.Exists(outputPath));
-            using var result = SkiaSharp.SKBitmap.Decode(outputPath);
+            using var result = SKBitmap.Decode(outputPath);
             Assert.NotNull(result);
             Assert.Equal(100, result.Width);
             Assert.Equal(100, result.Height);
@@ -192,7 +193,7 @@ namespace AmeCapture.Tests.Integration
             await _editorService.ApplyAnnotationsAsync(sourcePath, outputPath, annotations);
 
             Assert.True(File.Exists(outputPath));
-            using var result = SkiaSharp.SKBitmap.Decode(outputPath);
+            using var result = SKBitmap.Decode(outputPath);
             Assert.Equal(100, result.Width);
             Assert.Equal(100, result.Height);
         }

--- a/tests/AmeCapture.Tests/Integration/SettingsRepositoryTests.cs
+++ b/tests/AmeCapture.Tests/Integration/SettingsRepositoryTests.cs
@@ -41,7 +41,7 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task GetAsync_EmptyDb_ReturnsDefaultSettings()
         {
-            var settings = await _repo.GetAsync();
+            AppSettings settings = await _repo.GetAsync();
 
             Assert.Equal(string.Empty, settings.SavePath);
             Assert.Equal("png", settings.ImageFormat);
@@ -65,7 +65,7 @@ namespace AmeCapture.Tests.Integration
             };
 
             await _repo.SaveAsync(settings);
-            var loaded = await _repo.GetAsync();
+            AppSettings loaded = await _repo.GetAsync();
 
             Assert.Equal(@"C:\Users\user\Pictures\AmeCapture", loaded.SavePath);
             Assert.Equal("jpg", loaded.ImageFormat);
@@ -84,7 +84,7 @@ namespace AmeCapture.Tests.Integration
             settings.SavePath = "/updated";
             await _repo.SaveAsync(settings);
 
-            var loaded = await _repo.GetAsync();
+            AppSettings loaded = await _repo.GetAsync();
             Assert.Equal("/updated", loaded.SavePath);
         }
     }

--- a/tests/AmeCapture.Tests/Integration/SqliteCompatibilityTests.cs
+++ b/tests/AmeCapture.Tests/Integration/SqliteCompatibilityTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using AmeCapture.Domain.Entities;
 using AmeCapture.Infrastructure.Database;
 using AmeCapture.Infrastructure.Repositories;
@@ -43,13 +44,13 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task DatabaseInitializer_CreatesAllTables()
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText =
                 "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name";
 
             var tables = new List<string>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 tables.Add(reader.GetString(0));
@@ -64,13 +65,13 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task DatabaseInitializer_CreatesIndexes()
         {
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText =
                 "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name";
 
             var indexes = new List<string>();
-            using var reader = await command.ExecuteReaderAsync();
+            using DbDataReader reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
                 indexes.Add(reader.GetString(0));
@@ -86,8 +87,8 @@ namespace AmeCapture.Tests.Integration
             await DatabaseInitializer.InitializeAsync(_connectionFactory);
             await DatabaseInitializer.InitializeAsync(_connectionFactory);
 
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText =
                 "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
             long count = Convert.ToInt64(await command.ExecuteScalarAsync());
@@ -115,12 +116,12 @@ namespace AmeCapture.Tests.Integration
             await _tagRepo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
             await _tagRepo.AddTagToItemAsync("w1", "t1");
 
-            var tags = await _tagRepo.GetTagsForItemAsync("w1");
+            IReadOnlyList<Tag> tags = await _tagRepo.GetTagsForItemAsync("w1");
             _ = Assert.Single(tags);
 
             await _workspaceRepo.DeleteAsync("w1");
 
-            var tagsAfterDelete = await _tagRepo.GetTagsForItemAsync("w1");
+            IReadOnlyList<Tag> tagsAfterDelete = await _tagRepo.GetTagsForItemAsync("w1");
             Assert.Empty(tagsAfterDelete);
         }
 
@@ -129,8 +130,8 @@ namespace AmeCapture.Tests.Integration
         {
             await _workspaceRepo.AddAsync(CreateSampleItem("w1"));
 
-            using var connection = await _connectionFactory.CreateConnectionAsync();
-            using var command = connection.CreateCommand();
+            using DbConnection connection = await _connectionFactory.CreateConnectionAsync();
+            using DbCommand command = connection.CreateCommand();
             command.CommandText =
                 "INSERT INTO workspace_item_tags (workspace_item_id, tag_id) VALUES ('w1', 'nonexistent')";
 

--- a/tests/AmeCapture.Tests/Integration/TagRepositoryTests.cs
+++ b/tests/AmeCapture.Tests/Integration/TagRepositoryTests.cs
@@ -60,7 +60,7 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
             await _repo.AddAsync(new Tag { Id = "t2", Name = "tag2" });
 
-            var tags = await _repo.GetAllAsync();
+            IReadOnlyList<Tag> tags = await _repo.GetAllAsync();
             Assert.Equal(2, tags.Count);
             Assert.Equal("tag1", tags[0].Name);
             Assert.Equal("tag2", tags[1].Name);
@@ -71,7 +71,7 @@ namespace AmeCapture.Tests.Integration
         {
             await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
 
-            var found = await _repo.GetByIdAsync("t1");
+            Tag? found = await _repo.GetByIdAsync("t1");
             Assert.NotNull(found);
             Assert.Equal("tag1", found.Name);
 
@@ -83,7 +83,7 @@ namespace AmeCapture.Tests.Integration
         {
             await _repo.AddAsync(new Tag { Id = "t1", Name = "tag1" });
 
-            var found = await _repo.FindByNameAsync("tag1");
+            Tag? found = await _repo.FindByNameAsync("tag1");
             Assert.NotNull(found);
 
             Assert.Null(await _repo.FindByNameAsync("nonexistent"));
@@ -107,7 +107,7 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddTagToItemAsync("w1", "t1");
             await _repo.AddTagToItemAsync("w1", "t2");
 
-            var tags = await _repo.GetTagsForItemAsync("w1");
+            IReadOnlyList<Tag> tags = await _repo.GetTagsForItemAsync("w1");
             Assert.Equal(2, tags.Count);
         }
 
@@ -133,7 +133,7 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddAsync(new Tag { Id = "t3", Name = "tag3" });
 
             await _repo.SetTagsForItemAsync("w1", ["t1", "t2"]);
-            var tags = await _repo.GetTagsForItemAsync("w1");
+            IReadOnlyList<Tag> tags = await _repo.GetTagsForItemAsync("w1");
             Assert.Equal(2, tags.Count);
 
             await _repo.SetTagsForItemAsync("w1", ["t3"]);
@@ -151,7 +151,7 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddTagToItemAsync("w1", "t1");
             await _repo.AddTagToItemAsync("w2", "t1");
 
-            var ids = await _repo.GetItemIdsByTagAsync("t1");
+            IReadOnlyList<string> ids = await _repo.GetItemIdsByTagAsync("t1");
             Assert.Equal(2, ids.Count);
             Assert.Contains("w1", ids);
             Assert.Contains("w2", ids);
@@ -167,7 +167,7 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddTagToItemAsync("w1", "t1");
             await _repo.AddTagToItemAsync("w2", "t2");
 
-            var map = await _repo.GetAllTagsForItemsAsync(["w1", "w2"]);
+            IReadOnlyDictionary<string, IReadOnlyList<Tag>> map = await _repo.GetAllTagsForItemsAsync(["w1", "w2"]);
             Assert.Equal(2, map.Count);
             _ = Assert.Single(map["w1"]);
             _ = Assert.Single(map["w2"]);
@@ -176,7 +176,7 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task GetAllTagsForItems_EmptyInput_ReturnsEmpty()
         {
-            var map = await _repo.GetAllTagsForItemsAsync([]);
+            IReadOnlyDictionary<string, IReadOnlyList<Tag>> map = await _repo.GetAllTagsForItemsAsync([]);
             Assert.Empty(map);
         }
     }

--- a/tests/AmeCapture.Tests/Integration/WorkspaceRepositoryTests.cs
+++ b/tests/AmeCapture.Tests/Integration/WorkspaceRepositoryTests.cs
@@ -58,10 +58,10 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task AddAndGetById_ReturnsItem()
         {
-            var item = CreateSampleItem("id-1");
+            WorkspaceItem item = CreateSampleItem("id-1");
             await _repo.AddAsync(item);
 
-            var found = await _repo.GetByIdAsync("id-1");
+            WorkspaceItem? found = await _repo.GetByIdAsync("id-1");
 
             Assert.NotNull(found);
             Assert.Equal("id-1", found.Id);
@@ -76,14 +76,14 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task GetById_NotFound_ReturnsNull()
         {
-            var result = await _repo.GetByIdAsync("nonexistent");
+            WorkspaceItem? result = await _repo.GetByIdAsync("nonexistent");
             Assert.Null(result);
         }
 
         [Fact]
         public async Task GetAll_Empty_ReturnsEmptyList()
         {
-            var items = await _repo.GetAllAsync();
+            IReadOnlyList<WorkspaceItem> items = await _repo.GetAllAsync();
             Assert.Empty(items);
         }
 
@@ -94,14 +94,14 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddAsync(CreateSampleItem("id-2"));
             await _repo.AddAsync(CreateSampleItem("id-3"));
 
-            var items = await _repo.GetAllAsync();
+            IReadOnlyList<WorkspaceItem> items = await _repo.GetAllAsync();
             Assert.Equal(3, items.Count);
         }
 
         [Fact]
         public async Task Update_ModifiesItem()
         {
-            var item = CreateSampleItem("id-1");
+            WorkspaceItem item = CreateSampleItem("id-1");
             await _repo.AddAsync(item);
 
             item.Title = "Updated Title";
@@ -109,7 +109,7 @@ namespace AmeCapture.Tests.Integration
             item.UpdatedAt = "2026-01-02T00:00:00Z";
             await _repo.UpdateAsync(item);
 
-            var found = await _repo.GetByIdAsync("id-1");
+            WorkspaceItem? found = await _repo.GetByIdAsync("id-1");
             Assert.NotNull(found);
             Assert.Equal("Updated Title", found.Title);
             Assert.True(found.IsFavorite);
@@ -135,11 +135,11 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task VideoType_Roundtrips()
         {
-            var item = CreateSampleItem("id-v1");
+            WorkspaceItem item = CreateSampleItem("id-v1");
             item.ItemType = WorkspaceItemType.Video;
             await _repo.AddAsync(item);
 
-            var found = await _repo.GetByIdAsync("id-v1");
+            WorkspaceItem? found = await _repo.GetByIdAsync("id-v1");
             Assert.NotNull(found);
             Assert.Equal(WorkspaceItemType.Video, found.ItemType);
         }
@@ -162,7 +162,7 @@ namespace AmeCapture.Tests.Integration
             };
             await _repo.AddAsync(item);
 
-            var found = await _repo.GetByIdAsync("id-opt");
+            WorkspaceItem? found = await _repo.GetByIdAsync("id-opt");
             Assert.NotNull(found);
             Assert.Null(found.ThumbnailPath);
             Assert.Null(found.MetadataJson);
@@ -175,7 +175,7 @@ namespace AmeCapture.Tests.Integration
             await _repo.AddAsync(CreateSampleItem("id-2"));
             await _repo.AddAsync(CreateSampleItem("id-3"));
 
-            var items = await _repo.GetByIdsAsync(["id-1", "id-3"]);
+            IReadOnlyList<WorkspaceItem> items = await _repo.GetByIdsAsync(["id-1", "id-3"]);
             Assert.Equal(2, items.Count);
             Assert.All(items, i => Assert.True(i.Id is "id-1" or "id-3"));
         }
@@ -183,7 +183,7 @@ namespace AmeCapture.Tests.Integration
         [Fact]
         public async Task GetByIds_Empty_ReturnsEmptyList()
         {
-            var items = await _repo.GetByIdsAsync([]);
+            IReadOnlyList<WorkspaceItem> items = await _repo.GetByIdsAsync([]);
             Assert.Empty(items);
         }
     }


### PR DESCRIPTION
このプルリクエストは、主にC#ファイルにおいて `var` の代わりに明示的な型宣言を使用するようにコードベースをリファクタリングし、コードの可読性と保守性を向上させるものです。さらに、ワークフローやデータベース初期化の詳細についても更新を行っています。最も重要な変更点は以下の通りです。

**明示的な型指定によるコードベースのリファクタリング:**

* `App.xaml.cs`、`EditorViewModel.cs`、`WorkspaceViewModel.cs`、`EditorPage.xaml.cs` などの各ファイルにおいて、コードの明瞭性と型安全性を高めるため、ほとんどの `var` を明示的な型宣言（例: `IServiceProvider?`、`IMessenger`、`AppSettings`、`WorkspaceItem`、`SKCanvas` など）に置き換えました。 [[[1]](https://www.google.com/search?q=diffhunk://%23diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L58-R80)](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L58-R80) ... [[[20]](https://www.google.com/search?q=diffhunk://%23diff-31d5ed1a1349ec5c9126e1bda0b31e8d78f8e1f31228901339dc0c2280e2a7aaL287-R290)](diffhunk://#diff-31d5ed1a1349ec5c9126e1bda0b31e8d78f8e1f31228901339dc0c2280e2a7aaL287-R290)

**ワークフローとビルドの改善:**

* GitHub Actionsワークフローにおける `dotnet format` チェックの重大度レベルを `info` から `warning` に変更しました。これにより、フォーマット強制の運用に柔軟性を持たせています。

**データベース初期化の強化:**

* `DatabaseInitializer` および `SqliteConnectionFactory` において、`var` の代わりに明示的な型（`DbConnection`、`DbTransaction`、`DbCommand`、`SqliteCommand`）を使用するように更新しました。また、`System.Data.Common` の `using` ディレクティブを追加し、リソース管理の明確化とコードの整合性を向上させました。 [[[1]](https://www.google.com/search?q=diffhunk://%23diff-07240683b496f2c70f9ee79e5a165784701589c394924581fc9994316f74980bR1)](diffhunk://#diff-07240683b496f2c70f9ee79e5a165784701589c394924581fc9994316f74980bR1) [[[2]](https://www.google.com/search?q=diffhunk://%23diff-07240683b496f2c70f9ee79e5a165784701589c394924581fc9994316f74980bL10-R13)](diffhunk://#diff-07240683b496f2c70f9ee79e5a165784701589c394924581fc9994316f74980bL10-R13) [[[3]](https://www.google.com/search?q=diffhunk://%23diff-d5aa109556c317695ce7807dbf45d474c87323d27c2b293d00085c837bc44fe3L18-R18)](diffhunk://#diff-d5aa109556c317695ce7807dbf45d474c87323d27c2b293d00085c837bc44fe3L18-R18)

**APIの整合性と細かな改善:**

* メソッドのシグネチャと変数宣言を整理し、一貫性と null 許容型の処理を改善しました（例: 適切な場所での null 許容型の使用や、メソッド引数における不要な名前空間プレフィックスの削除など）。 [[[1]](https://www.google.com/search?q=diffhunk://%23diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L101-R103)](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L101-R103) [[[2]](https://www.google.com/search?q=diffhunk://%23diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L110-R112)](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L110-R112) [[[3]](https://www.google.com/search?q=diffhunk://%23diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L125-R127)](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L125-R127) [[[4]](https://www.google.com/search?q=diffhunk://%23diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L35-R37)](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045L35-R37)

これらの変更により、コードの品質、保守性、および開発体験が総合的に向上します。