### PR TITLE
Fix app exit hang, toolbar title removal, and font loading issues

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -15,7 +15,47 @@ on:
       - ".github/workflows/dotnet-ci.yml"
 
 jobs:
+  suppression-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for static analysis suppression comments
+        shell: bash
+        run: |
+          PATTERNS=(
+            "#pragma warning disable"
+            "#pragma warning restore"
+            "SuppressMessage"
+            "pyright: ignore"
+            "type: ignore"
+            "# noqa"
+            "pylint: disable"
+            "// @ts-ignore"
+            "// @ts-nocheck"
+            "eslint-disable"
+            "prettier-ignore"
+            "// eslint-disable-next-line"
+          )
+          FOUND=0
+          for pattern in "${PATTERNS[@]}"; do
+            MATCHES=$(grep -rn "$pattern" --include="*.cs" --include="*.py" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" src/ 2>/dev/null || true)
+            if [ -n "$MATCHES" ]; then
+              echo "::error::Suppression comment '$pattern' found:"
+              echo "$MATCHES"
+              FOUND=1
+            fi
+          done
+          if [ "$FOUND" -ne 0 ]; then
+            echo ""
+            echo "❌ Static analysis suppression comments detected."
+            echo "Do not suppress lint/type errors. Fix the root cause instead."
+            exit 1
+          fi
+          echo "✅ No suppression comments found."
+
   build:
+    needs: suppression-check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +75,7 @@ jobs:
         run: dotnet build src/AmeCapture.App/AmeCapture.App.csproj -f net10.0-windows10.0.19041.0 --no-restore -warnaserror
 
   test:
+    needs: suppression-check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +95,7 @@ jobs:
         run: dotnet test tests/AmeCapture.Tests/AmeCapture.Tests.csproj --no-build --verbosity normal
 
   lint:
+    needs: suppression-check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -2,9 +2,40 @@
 
 echo "=== Pre-commit checks (CI equivalent or stricter) ==="
 
+# 0. Check for static analysis suppression comments
+echo ""
+echo "[0/4] Checking for static analysis suppression comments..."
+SUPPRESSION_PATTERNS="-e #pragma\ warning\ disable \
+  -e \#pragma\ warning\ restore \
+  -e SuppressMessage \
+  -e pyright:\ ignore \
+  -e type:\ ignore \
+  -e noqa \
+  -e pylint:\ disable \
+  -e //\ @ts-ignore \
+  -e //\ @ts-nocheck \
+  -e eslint-disable \
+  -e prettier-ignore \
+  -e //\ eslint-disable-next-line"
+FOUND_FILES=""
+for pattern in $SUPPRESSION_PATTERNS; do
+  MATCHES=$(grep -rn "$pattern" --include="*.cs" --include="*.py" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" src/ 2>/dev/null || true)
+  if [ -n "$MATCHES" ]; then
+    FOUND_FILES="$FOUND_FILES$MATCHES\n"
+  fi
+done
+if [ -n "$FOUND_FILES" ]; then
+  echo ""
+  echo "❌ Static analysis suppression comments detected:"
+  echo "$FOUND_FILES"
+  echo "Do not suppress lint/type errors. Fix the root cause instead."
+  exit 1
+fi
+echo "No suppression comments found."
+
 # 1. Format check (lint) — CI uses --severity warn
 echo ""
-echo "[1/3] Running dotnet format check..."
+echo "[1/4] Running dotnet format check..."
 dotnet format AmeCapture.slnx --verify-no-changes --severity warn
 if [ $? -ne 0 ]; then
   echo ""
@@ -14,7 +45,7 @@ fi
 
 # 2. Build — same as CI (-warnaserror)
 echo ""
-echo "[2/3] Running dotnet build..."
+echo "[2/4] Running dotnet build..."
 dotnet restore AmeCapture.slnx
 dotnet build src/AmeCapture.App/AmeCapture.App.csproj -f net10.0-windows10.0.19041.0 --no-restore -warnaserror
 if [ $? -ne 0 ]; then
@@ -25,7 +56,7 @@ fi
 
 # 3. Test — same as CI
 echo ""
-echo "[3/3] Running dotnet test..."
+echo "[3/4] Running dotnet test..."
 dotnet restore tests/AmeCapture.Tests/AmeCapture.Tests.csproj
 dotnet build tests/AmeCapture.Tests/AmeCapture.Tests.csproj --no-restore
 dotnet test tests/AmeCapture.Tests/AmeCapture.Tests.csproj --no-build --verbosity normal

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -5,25 +5,21 @@ echo "=== Pre-commit checks (CI equivalent or stricter) ==="
 # 0. Check for static analysis suppression comments
 echo ""
 echo "[0/4] Checking for static analysis suppression comments..."
-SUPPRESSION_PATTERNS="-e #pragma\ warning\ disable \
-  -e \#pragma\ warning\ restore \
-  -e SuppressMessage \
-  -e pyright:\ ignore \
-  -e type:\ ignore \
-  -e noqa \
-  -e pylint:\ disable \
-  -e //\ @ts-ignore \
-  -e //\ @ts-nocheck \
-  -e eslint-disable \
-  -e prettier-ignore \
-  -e //\ eslint-disable-next-line"
-FOUND_FILES=""
-for pattern in $SUPPRESSION_PATTERNS; do
-  MATCHES=$(grep -rn "$pattern" --include="*.cs" --include="*.py" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" src/ 2>/dev/null || true)
-  if [ -n "$MATCHES" ]; then
-    FOUND_FILES="$FOUND_FILES$MATCHES\n"
-  fi
-done
+FOUND_FILES=$(grep -rn \
+  -e "#pragma warning disable" \
+  -e "#pragma warning restore" \
+  -e "SuppressMessage" \
+  -e "pyright: ignore" \
+  -e "type: ignore" \
+  -e "noqa" \
+  -e "pylint: disable" \
+  -e "// @ts-ignore" \
+  -e "// @ts-nocheck" \
+  -e "eslint-disable" \
+  -e "prettier-ignore" \
+  -e "// eslint-disable-next-line" \
+  --include="*.cs" --include="*.py" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" \
+  src/ 2>/dev/null || true)
 if [ -n "$FOUND_FILES" ]; then
   echo ""
   echo "❌ Static analysis suppression comments detected:"

--- a/src/AmeCapture.App/App.xaml.cs
+++ b/src/AmeCapture.App/App.xaml.cs
@@ -168,7 +168,6 @@ namespace AmeCapture.App
             _trayService?.Exit();
             Serilog.Log.CloseAndFlush();
             Quit();
-            Environment.Exit(0);
         }
     }
 }

--- a/src/AmeCapture.App/App.xaml.cs
+++ b/src/AmeCapture.App/App.xaml.cs
@@ -24,6 +24,12 @@ namespace AmeCapture.App
         {
             InitializeComponent();
             UserAppTheme = AppTheme.Dark;
+
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true;
+                MainThread.BeginInvokeOnMainThread(Exit);
+            };
         }
 
         protected override Window CreateWindow(IActivationState? activationState)
@@ -155,8 +161,14 @@ namespace AmeCapture.App
         public void Exit()
         {
             _isExiting = true;
+            if (_shortcutService is IDisposable shortcutDisposable)
+            {
+                shortcutDisposable.Dispose();
+            }
             _trayService?.Exit();
+            Serilog.Log.CloseAndFlush();
             Quit();
+            Environment.Exit(0);
         }
     }
 }

--- a/src/AmeCapture.App/MauiProgram.cs
+++ b/src/AmeCapture.App/MauiProgram.cs
@@ -60,6 +60,7 @@ namespace AmeCapture.App
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
                 {
+                    fonts.AddFont("NotoSansJP-Regular.otf", "Noto Sans JP");
                 });
 
             string basePath = Path.Combine(

--- a/src/AmeCapture.App/Views/WorkspacePage.xaml
+++ b/src/AmeCapture.App/Views/WorkspacePage.xaml
@@ -10,10 +10,6 @@
 
     <Grid RowDefinitions="Auto,*">
         <HorizontalStackLayout Grid.Row="0" Padding="16,8" Spacing="12">
-            <Label Text="AmeCapture"
-                   FontSize="24"
-                   FontAttributes="Bold"
-                   VerticalOptions="Center" />
             <Button Text="領域"
                     Command="{Binding PrepareRegionCaptureCommand}"
                     SemanticProperties.Description="Capture region" />


### PR DESCRIPTION
This pull request introduces a new static analysis suppression comment check to both the CI workflow and the pre-commit hook, ensuring that developers do not bypass linting or type checks by suppressing warnings. Additionally, it improves application shutdown handling and makes a minor UI and font update.

**Automated static analysis suppression enforcement:**

- Added a `suppression-check` job to `.github/workflows/dotnet-ci.yml` that scans for suppression comments (e.g., `#pragma warning disable`, `// @ts-ignore`, `# noqa`) in source files and fails the build if any are found. The `build`, `test`, and `lint` jobs now depend on passing this check. [[1]](diffhunk://#diff-bd6c1bcfcaa13ae3662b9fbb7e13fa55a46715d4ba656f6d663717d309101b6dR18-R58) [[2]](diffhunk://#diff-bd6c1bcfcaa13ae3662b9fbb7e13fa55a46715d4ba656f6d663717d309101b6dR78) [[3]](diffhunk://#diff-bd6c1bcfcaa13ae3662b9fbb7e13fa55a46715d4ba656f6d663717d309101b6dR98)
- Updated the pre-commit hook (`.husky/_/pre-commit`) to include a similar suppression comment check, preventing commits that introduce such comments.

**Developer workflow improvements:**

- Adjusted pre-commit hook step numbering to accommodate the new suppression check, and updated messaging for clarity. [[1]](diffhunk://#diff-e08f9f57d85ffece80ebd97d87f0f7077759cc8eecfd667455047685fb300ebdL17-R48) [[2]](diffhunk://#diff-e08f9f57d85ffece80ebd97d87f0f7077759cc8eecfd667455047685fb300ebdL28-R59)

**Application shutdown and resource management:**

- Improved graceful shutdown in `App.xaml.cs` by handling `Console.CancelKeyPress` (Ctrl+C), disposing of the shortcut service if necessary, flushing logs, and ensuring the process exits cleanly. [[1]](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045R27-R32) [[2]](diffhunk://#diff-18a2cba41ef952b52e4b2e4166721c57c9c9bb4ba6bf9eca3114690716447045R164-R171)

**UI and font updates:**

- Added the "Noto Sans JP" font to the app's font configuration in `MauiProgram.cs`.
- Removed the "AmeCapture" label from the top of the `WorkspacePage.xaml` UI.