### PR TITLE
Add Japanese font support and improve image loading error handling

### DIFF
--- a/src/AmeCapture.App/App.xaml.cs
+++ b/src/AmeCapture.App/App.xaml.cs
@@ -5,9 +5,11 @@ using AmeCapture.Infrastructure.Database;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI;
 
+using MauiApp = Microsoft.Maui.Controls.Application;
+
 namespace AmeCapture.App
 {
-    public partial class App : Microsoft.Maui.Controls.Application
+    public partial class App : MauiApp
     {
         private ITrayService? _trayService;
         private IGlobalShortcutService? _shortcutService;
@@ -156,7 +158,7 @@ namespace AmeCapture.App
             }
             _trayService?.Exit();
             Serilog.Log.CloseAndFlush();
-            Environment.Exit(0);
+            Current?.Quit();
         }
     }
 }

--- a/src/AmeCapture.App/App.xaml.cs
+++ b/src/AmeCapture.App/App.xaml.cs
@@ -13,23 +13,12 @@ namespace AmeCapture.App
         private IGlobalShortcutService? _shortcutService;
         private ISettingsRepository? _settingsRepository;
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        [System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.System32)]
-        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-        private const int SW_HIDE = 0;
-
         private bool _isExiting;
 
         public App()
         {
             InitializeComponent();
             UserAppTheme = AppTheme.Dark;
-
-            Console.CancelKeyPress += (sender, e) =>
-            {
-                e.Cancel = true;
-                MainThread.BeginInvokeOnMainThread(Exit);
-            };
         }
 
         protected override Window CreateWindow(IActivationState? activationState)
@@ -49,7 +38,7 @@ namespace AmeCapture.App
                         if (!_isExiting)
                         {
                             args.Cancel = true;
-                            _ = ShowWindow(hWnd, SW_HIDE);
+                            Exit();
                         }
                     };
                 }
@@ -167,7 +156,7 @@ namespace AmeCapture.App
             }
             _trayService?.Exit();
             Serilog.Log.CloseAndFlush();
-            Quit();
+            Environment.Exit(0);
         }
     }
 }

--- a/src/AmeCapture.App/Platforms/Windows/App.xaml
+++ b/src/AmeCapture.App/Platforms/Windows/App.xaml
@@ -7,7 +7,7 @@
 
     <maui:MauiWinUIApplication.Resources>
         <ResourceDictionary>
-            <FontFamily x:Key="ContentControlThemeFontFamily">ms-appx:///NotoSansJP-Regular.otf#Noto Sans JP</FontFamily>
+            <FontFamily x:Key="ContentControlThemeFontFamily">Noto Sans JP</FontFamily>
         </ResourceDictionary>
     </maui:MauiWinUIApplication.Resources>
 

--- a/src/AmeCapture.App/Platforms/Windows/App.xaml
+++ b/src/AmeCapture.App/Platforms/Windows/App.xaml
@@ -5,4 +5,10 @@
     xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:AmeCapture.App.WinUI">
 
+    <maui:MauiWinUIApplication.Resources>
+        <ResourceDictionary>
+            <FontFamily x:Key="ContentControlThemeFontFamily">ms-appx:///NotoSansJP-Regular.otf#Noto Sans JP</FontFamily>
+        </ResourceDictionary>
+    </maui:MauiWinUIApplication.Resources>
+
 </maui:MauiWinUIApplication>

--- a/src/AmeCapture.App/Views/EditorPage.xaml.cs
+++ b/src/AmeCapture.App/Views/EditorPage.xaml.cs
@@ -90,6 +90,11 @@ namespace AmeCapture.App.Views
                     Serilog.Log.Debug("EditorPage.LoadImage: decoded bitmap {Width}x{Height}", bitmap.Width, bitmap.Height);
                     MainThread.BeginInvokeOnMainThread(() =>
                     {
+                        if (_viewModel.ImagePath != filePath)
+                        {
+                            bitmap.Dispose();
+                            return;
+                        }
                         _sourceBitmap?.Dispose();
                         _sourceBitmap = bitmap;
                         CanvasView.InvalidateSurface();

--- a/src/AmeCapture.App/Views/EditorPage.xaml.cs
+++ b/src/AmeCapture.App/Views/EditorPage.xaml.cs
@@ -75,21 +75,30 @@ namespace AmeCapture.App.Views
                 return;
             }
 
+            string filePath = _viewModel.ImagePath;
+
             _ = Task.Run(() =>
             {
-                var bitmap = SKBitmap.Decode(_viewModel.ImagePath);
-                if (bitmap == null)
+                try
                 {
-                    Serilog.Log.Warning("EditorPage.LoadImage: failed to decode bitmap from {ImagePath}", _viewModel.ImagePath);
-                    return;
+                    var bitmap = SKBitmap.Decode(filePath);
+                    if (bitmap == null)
+                    {
+                        Serilog.Log.Warning("EditorPage.LoadImage: failed to decode bitmap from {ImagePath}", filePath);
+                        return;
+                    }
+                    Serilog.Log.Debug("EditorPage.LoadImage: decoded bitmap {Width}x{Height}", bitmap.Width, bitmap.Height);
+                    MainThread.BeginInvokeOnMainThread(() =>
+                    {
+                        _sourceBitmap?.Dispose();
+                        _sourceBitmap = bitmap;
+                        CanvasView.InvalidateSurface();
+                    });
                 }
-                Serilog.Log.Debug("EditorPage.LoadImage: decoded bitmap {Width}x{Height}", bitmap.Width, bitmap.Height);
-                MainThread.BeginInvokeOnMainThread(() =>
+                catch (Exception ex)
                 {
-                    _sourceBitmap?.Dispose();
-                    _sourceBitmap = bitmap;
-                    CanvasView.InvalidateSurface();
-                });
+                    Serilog.Log.Error(ex, "EditorPage.LoadImage: failed to decode image from {ImagePath}", filePath);
+                }
             });
         }
 


### PR DESCRIPTION
このプルリクエストでは、アプリケーションの安定性、エラーハンドリング、およびユーザーインターフェースの一貫性に関するいくつかの改善が行われました。主な変更点として、画像読み込み時のエラーログ出力の強化、アプリケーション終了プロセスの堅牢化、およびWindowsプラットフォーム向けカスタムフォントの追加が含まれています。

**エラーハンドリングと安定性：**

* **画像読み込みの改善:** `EditorPage.xaml.cs` における画像の読み込み処理を try-catch ブロックで囲みました。これにより、画像のデコード失敗時にエラーをログに記録できるようになり、診断機能の向上とクラッシュの防止を実現しました。
* **終了プロセスの刷新:** `App.xaml.cs` におけるアプリケーションの終了プロセスを、独自の `Quit()` メソッドから `Environment.Exit(0)` に変更しました。これにより、より確実なシャットダウンとリソースのクリーンアップが保証されます。
* **ロジックの簡素化:** Win32 API の `ShowWindow` の使用を廃止し、終了ロジックを直接呼び出すように変更することで、ウィンドウを閉じるロジックを簡素化しました。これにより、プラットフォーム固有の依存関係が削減されました。

**ユーザーインターフェースの改善：**

* **フォントの最適化:** `App.xaml` を更新し、Windowsプラットフォームのデフォルトコンテンツフォントとしてカスタムフォント（`Noto Sans JP`）を追加しました。これにより、日本語テキストのUIの一貫性が向上します。

**変更点リスト（要約）：**
- Windowsプラットフォーム向けに Noto Sans JP フォントの設定を追加
- try-catch による画像読み込み時のエラーハンドリングの改善
- ShowWindow インタロップ呼び出しを削除し、アプリの終了フローを簡素化